### PR TITLE
Add format emit strategies to libslide

### DIFF
--- a/libslide/src/emit.rs
+++ b/libslide/src/emit.rs
@@ -1,0 +1,287 @@
+//! Emit strategies for the libslide grammar IR.
+
+use crate::grammar::*;
+
+use core::fmt;
+use std::rc::Rc;
+
+/// The format in which a slide grammar should be emitted.
+#[derive(Copy, Clone)]
+pub enum EmitFormat {
+    /// Canonical, human-readable form.
+    /// For example, `1+1` is output as `1 + 1`.
+    Pretty,
+    /// S-expression form.
+    /// For example, `1+1` is output as `(+ 1 1)`.
+    SExpression,
+    /// LaTeX output form.
+    /// For example, `(1 + 1)` is output as `\left\(1 + 1\right\)`.
+    /// NB: this is not yet implemented.
+    Latex,
+    /// Slide internal debug form.
+    /// NB: this form is not stable, and no assumptions should be made about it.
+    Debug,
+}
+
+/// Implements the emission of a type in an [EmitFormat][EmitFormat].
+pub trait Emit
+where
+    // These are trivially implementable using `emit_pretty` and `emit_debug`. The easiest way to
+    // do this is with the `fmt_emit_impl` macro.
+    Self: fmt::Display + fmt::Debug,
+{
+    /// Emit `self` with the given [EmitFormat][EmitFormat].
+    fn emit(&self, form: EmitFormat) -> String {
+        match form {
+            EmitFormat::Pretty => self.emit_pretty(),
+            EmitFormat::SExpression => self.emit_s_expression(),
+            EmitFormat::Latex => self.emit_latex(),
+            EmitFormat::Debug => self.emit_debug(),
+        }
+    }
+
+    /// Emit `self` with the [pretty emit format][EmitFormat::Pretty]
+    fn emit_pretty(&self) -> String;
+
+    /// Emit `self` with the [debug emit format][EmitFormat::Debug]
+    fn emit_debug(&self) -> String {
+        format!("{:#?}", self)
+    }
+
+    /// Emit `self` with the [s_expression emit format][EmitFormat::SExpression]
+    fn emit_s_expression(&self) -> String {
+        unimplemented!();
+    }
+
+    /// Emit `self` with the [LaTeX emit format][EmitFormat::Latex]
+    fn emit_latex(&self) -> String {
+        unimplemented!();
+    }
+}
+
+/// Implements `core::fmt::Display` for a type implementing `Emit`.
+/// TODO: Maybe this can be a proc macro?
+#[doc(hidden)]
+macro_rules! fmt_emit_impl {
+    ($S:path) => {
+        impl core::fmt::Display for $S {
+            fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                write!(f, "{}", self.emit_pretty(),)
+            }
+        }
+    };
+}
+
+fmt_emit_impl!(Stmt);
+impl Emit for Stmt {
+    fn emit_pretty(&self) -> String {
+        match self {
+            Self::Expr(expr) => expr.emit_pretty(),
+            Self::Assignment(asgn) => asgn.emit_pretty(),
+        }
+    }
+
+    fn emit_s_expression(&self) -> String {
+        match self {
+            Self::Expr(expr) => expr.emit_s_expression(),
+            Self::Assignment(Assignment { var, rhs }) => {
+                format!("(= {} {})", var, rhs.emit_s_expression())
+            }
+        }
+    }
+}
+
+fmt_emit_impl!(Assignment);
+impl Emit for Assignment {
+    fn emit_pretty(&self) -> String {
+        format!("{} = {}", self.var, self.rhs)
+    }
+}
+
+fmt_emit_impl!(Expr);
+impl Emit for Expr {
+    fn emit_pretty(&self) -> String {
+        match self {
+            Self::Const(num) => num.to_string(),
+            Self::Var(var) => var.to_string(),
+            Self::BinaryExpr(binary_expr) => binary_expr.emit_pretty(),
+            Self::UnaryExpr(unary_expr) => unary_expr.emit_pretty(),
+            Self::Parend(expr) => format!("({})", expr.emit_pretty()),
+            Self::Bracketed(expr) => format!("[{}]", expr.emit_pretty()),
+        }
+    }
+    fn emit_s_expression(&self) -> String {
+        match self {
+            Self::Const(konst) => konst.to_string(),
+            Self::Var(var) => var.to_string(),
+            Self::BinaryExpr(BinaryExpr { op, lhs, rhs }) => format!(
+                "({} {} {})",
+                op.emit_pretty(),
+                lhs.emit_s_expression(),
+                rhs.emit_s_expression()
+            ),
+            Self::UnaryExpr(UnaryExpr { op, rhs }) => {
+                format!("({} {})", op.emit_pretty(), rhs.emit_s_expression())
+            }
+            Self::Parend(inner) => format!("({})", inner.emit_s_expression()),
+            Self::Bracketed(inner) => format!("[{}]", inner.emit_s_expression()),
+        }
+    }
+}
+
+impl Emit for Rc<Expr> {
+    fn emit_pretty(&self) -> String {
+        self.as_ref().emit_pretty()
+    }
+
+    fn emit_s_expression(&self) -> String {
+        self.as_ref().emit_s_expression()
+    }
+}
+
+fmt_emit_impl!(BinaryOperator);
+impl Emit for BinaryOperator {
+    fn emit_pretty(&self) -> String {
+        match self {
+            Self::Plus => "+",
+            Self::Minus => "-",
+            Self::Mult => "*",
+            Self::Div => "/",
+            Self::Mod => "%",
+            Self::Exp => "^",
+        }
+        .to_owned()
+    }
+}
+
+macro_rules! display_binary_expr {
+    (<$expr:ident>) => {
+        fmt_emit_impl!(BinaryExpr<$expr>);
+        impl Emit for BinaryExpr<$expr> {
+            fn emit_pretty(&self) -> String {
+                let mut result = String::with_capacity(128);
+                use $expr::*;
+                let format_arg = |arg: &Rc<$expr>, right_child: bool| match arg.as_ref() {
+                    // We want to format items like
+                    //    v--------- child op
+                    //         v---- parent op
+                    // (3 + 5) ^ 2 [1]
+                    //  3 + 5  + 2
+                    //  3 - 5  + 2
+                    //  3 * 5  + 2
+                    // and
+                    //   v---------- parent op
+                    //        v----- child op
+                    // 2 +  3 + 5
+                    // 2 - (3 + 5)
+                    // 2 * (3 + 5)
+                    //
+                    // So the idea here is as follows:
+                    // - if the child op precedence is less than the parent op, we must always
+                    //   parenthesize it ([1])
+                    // - if the op precedences are equivalent, then
+                    //   - if the child is on the LHS, we can always unwrap it
+                    //   - if the child is on the RHS, we parenthesize it unless the parent op is
+                    //     associative
+                    //
+                    // I think this is enough, but maybe we're overlooking left/right
+                    // associativity?
+                    BinaryExpr(child) => {
+                        if child.op.precedence() < self.op.precedence()
+                            || (right_child
+                                && child.op.precedence() == self.op.precedence()
+                                && !self.op.is_associative())
+                        {
+                            format!("({})", child)
+                        } else {
+                            child.emit_pretty()
+                        }
+                    }
+                    expr => expr.emit_pretty(),
+                };
+                result.push_str(&format!(
+                    "{} {} {}",
+                    format_arg(&self.lhs, false),
+                    self.op,
+                    format_arg(&self.rhs, true)
+                ));
+                result
+            }
+        }
+    };
+}
+display_binary_expr!(<Expr>);
+display_binary_expr!(<ExprPat>);
+
+fmt_emit_impl!(UnaryOperator);
+impl Emit for UnaryOperator {
+    fn emit_pretty(&self) -> String {
+        match self {
+            Self::SignPositive => "+",
+            Self::SignNegative => "-",
+        }
+        .to_owned()
+    }
+}
+
+macro_rules! display_unary_expr {
+    (<$expr:ident>) => {
+        fmt_emit_impl!(UnaryExpr<$expr>);
+        impl Emit for UnaryExpr<$expr> {
+            fn emit_pretty(&self) -> String {
+                let mut result = String::with_capacity(128);
+                use $expr::*;
+                let format_arg = |arg: &Rc<$expr>| match arg.as_ref() {
+                    BinaryExpr(l) => format!("({})", l),
+                    expr => expr.emit_pretty(),
+                };
+                result.push_str(&format!("{}{}", self.op, format_arg(&self.rhs)));
+                result
+            }
+        }
+    };
+}
+display_unary_expr!(<Expr>);
+display_unary_expr!(<ExprPat>);
+
+fmt_emit_impl!(ExprPat);
+impl Emit for ExprPat {
+    fn emit_pretty(&self) -> String {
+        match self {
+            Self::Const(num) => num.to_string(),
+            Self::VarPat(var) | Self::ConstPat(var) | Self::AnyPat(var) => var.to_string(),
+            Self::BinaryExpr(binary_expr) => binary_expr.emit_pretty(),
+            Self::UnaryExpr(unary_expr) => unary_expr.emit_pretty(),
+            Self::Parend(expr) => format!("({})", expr.emit_pretty()),
+            Self::Bracketed(expr) => format!("[{}]", expr.emit_pretty()),
+        }
+    }
+
+    fn emit_s_expression(&self) -> String {
+        match self {
+            Self::Const(konst) => konst.to_string(),
+            Self::VarPat(pat) | Self::ConstPat(pat) | Self::AnyPat(pat) => pat.to_string(),
+            Self::BinaryExpr(BinaryExpr { op, lhs, rhs }) => format!(
+                "({} {} {})",
+                op.to_string(),
+                lhs.emit_s_expression(),
+                rhs.emit_s_expression()
+            ),
+            Self::UnaryExpr(UnaryExpr { op, rhs }) => {
+                format!("({} {})", op.to_string(), rhs.emit_s_expression())
+            }
+            Self::Parend(inner) => format!("({})", inner.emit_s_expression()),
+            Self::Bracketed(inner) => format!("[{}]", inner.emit_s_expression()),
+        }
+    }
+}
+
+impl Emit for Rc<ExprPat> {
+    fn emit_pretty(&self) -> String {
+        self.as_ref().emit_pretty()
+    }
+
+    fn emit_s_expression(&self) -> String {
+        self.as_ref().emit_s_expression()
+    }
+}

--- a/libslide/src/grammar/pattern.rs
+++ b/libslide/src/grammar/pattern.rs
@@ -17,27 +17,8 @@ pub enum ExprPat {
     Bracketed(Rc<Self>),
 }
 
-impl Grammar for ExprPat {
-    fn s_form(&self) -> String {
-        match self {
-            Self::Const(konst) => konst.to_string(),
-            Self::VarPat(pat) | Self::ConstPat(pat) | Self::AnyPat(pat) => pat.to_string(),
-            Self::BinaryExpr(BinaryExpr { op, lhs, rhs }) => {
-                format!("({} {} {})", op.to_string(), lhs.s_form(), rhs.s_form())
-            }
-            Self::UnaryExpr(UnaryExpr { op, rhs }) => {
-                format!("({} {})", op.to_string(), rhs.s_form())
-            }
-            Self::Parend(inner) => format!("({})", inner.s_form()),
-            Self::Bracketed(inner) => format!("[{}]", inner.s_form()),
-        }
-    }
-}
-impl Grammar for Rc<ExprPat> {
-    fn s_form(&self) -> String {
-        self.as_ref().s_form()
-    }
-}
+impl Grammar for ExprPat {}
+impl Grammar for Rc<ExprPat> {}
 
 impl Expression for ExprPat {
     #[inline]
@@ -111,24 +92,6 @@ impl From<BinaryExpr<Self>> for ExprPat {
 impl From<UnaryExpr<Self>> for ExprPat {
     fn from(unary_expr: UnaryExpr<Self>) -> Self {
         Self::UnaryExpr(unary_expr)
-    }
-}
-
-impl fmt::Display for ExprPat {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        use ExprPat::*;
-        write!(
-            f,
-            "{}",
-            match self {
-                Const(num) => num.to_string(),
-                VarPat(var) | ConstPat(var) | AnyPat(var) => var.to_string(),
-                BinaryExpr(binary_expr) => binary_expr.to_string(),
-                UnaryExpr(unary_expr) => unary_expr.to_string(),
-                Parend(expr) => format!("({})", expr.to_string()),
-                Bracketed(expr) => format!("[{}]", expr.to_string()),
-            }
-        )
     }
 }
 

--- a/libslide/src/lib.rs
+++ b/libslide/src/lib.rs
@@ -221,6 +221,10 @@ pub use grammar::Grammar;
 
 mod math;
 
+pub(crate) mod emit;
+pub use emit::Emit;
+pub use emit::EmitFormat;
+
 #[cfg(feature = "benchmark-internals")]
 pub use math::*;
 

--- a/libslide/src/partial_evaluator/flatten.rs
+++ b/libslide/src/partial_evaluator/flatten.rs
@@ -491,6 +491,7 @@ mod tests {
     use super::flatten_expr;
     use crate::grammar::*;
     use crate::utils::normalize;
+    use crate::Emit;
     use crate::{parse_expression, scan};
 
     use std::rc::Rc;
@@ -533,7 +534,7 @@ mod tests {
             let expr = parse(split.next().unwrap());
             let expected_flattened = split.next().unwrap();
 
-            let flattened = normalize(flatten_expr(&Rc::from(expr))).s_form();
+            let flattened = normalize(flatten_expr(&Rc::from(expr))).emit_s_expression();
 
             assert_eq!(flattened, expected_flattened);
         }

--- a/slide/src/lib.rs
+++ b/slide/src/lib.rs
@@ -12,15 +12,15 @@ use diagnostics::emit_slide_diagnostics;
 use libslide::diagnostics::Diagnostic;
 use libslide::scanner::ScanResult;
 use libslide::{
-    evaluate, parse_expression, parse_expression_pattern, scan, EvaluatorContext, Grammar,
+    evaluate, parse_expression, parse_expression_pattern, scan, Emit, EmitFormat, EvaluatorContext,
 };
 
 /// Options to run slide with.
 pub struct Opts {
     /// Slide program.
     pub program: String,
-    /// How the result of slide's execution should be output.
-    pub output_form: OutputForm,
+    /// How the result of slide's execution should be emitted.
+    pub emit_format: EmitFormat,
     /// When true, slide will stop after parsing a program.
     pub parse_only: bool,
     /// When true, slide will expect the program to be an expression pattern.
@@ -29,26 +29,16 @@ pub struct Opts {
     pub no_emit: bool,
 }
 
-/// How the result of slide should be output.
-#[derive(Copy, Clone)]
-pub enum OutputForm {
-    /// Canonical, human-readable form.
-    /// For example, `1+1` is output as `1 + 1`.
-    Pretty,
-    /// S-expression form.
-    /// For example, `1+1` is output as `(+ 1 1)`.
-    SExpression,
-    /// Slide internal debug form.
-    /// NB: this form is not stable, and no assumptions should be made about it.
-    Debug,
-}
-
 /// Runs slide end-to-end.
 pub fn run_slide(opts: Opts) -> i32 {
-    let output_form = opts.output_form;
+    let Opts {
+        emit_format,
+        program,
+        no_emit,
+        ..
+    } = opts;
+    let emit = !no_emit;
     let file = None; // currently programs can only be read from stdin
-    let program = opts.program;
-    let emit = !opts.no_emit;
 
     let emit_diagnostics = |diagnostics: Vec<Diagnostic>| {
         if emit {
@@ -56,9 +46,9 @@ pub fn run_slide(opts: Opts) -> i32 {
         }
         1
     };
-    let emit_tree = move |obj: &dyn Grammar| {
+    let emit_tree = move |obj: &dyn Emit| {
         if emit {
-            println!("{}", print(obj, output_form));
+            println!("{}", obj.emit(emit_format));
         }
         0
     };
@@ -93,12 +83,4 @@ pub fn run_slide(opts: Opts) -> i32 {
 
     let simplified = evaluate(parse_tree, EvaluatorContext::default()).unwrap();
     emit_tree(&simplified)
-}
-
-fn print(obj: &dyn Grammar, output_form: OutputForm) -> String {
-    match output_form {
-        OutputForm::Pretty => obj.to_string(),
-        OutputForm::SExpression => obj.s_form(),
-        OutputForm::Debug => format!("{:#?}", obj),
-    }
 }

--- a/slide/src/main.rs
+++ b/slide/src/main.rs
@@ -1,4 +1,5 @@
-use slide::{run_slide, Opts, OutputForm};
+use libslide::EmitFormat;
+use slide::{run_slide, Opts};
 use std::env;
 
 fn get_opts() -> Opts {
@@ -33,10 +34,11 @@ fn get_opts() -> Opts {
     let expr_pat = matches.is_present("expr-pat");
     Opts {
         program: matches.value_of("program").unwrap().into(),
-        output_form: match matches.value_of("output-form").unwrap() {
-            "pretty" => OutputForm::Pretty,
-            "s-expression" => OutputForm::SExpression,
-            "debug" => OutputForm::Debug,
+        // TODO: we should consolidate emit_format and output-form before any stable release.
+        emit_format: match matches.value_of("output-form").unwrap() {
+            "pretty" => EmitFormat::Pretty,
+            "s-expression" => EmitFormat::SExpression,
+            "debug" => EmitFormat::Debug,
             _ => unreachable!(),
         },
         parse_only: matches.is_present("parse-only") || expr_pat,

--- a/slide/src/test/mod.rs
+++ b/slide/src/test/mod.rs
@@ -65,10 +65,7 @@ fn get_clause_delim(clause: &str) -> String {
 
 /// Returns whether a clause can be auto-generated with --bless.
 fn can_be_blessed(clause: &str) -> bool {
-    match clause {
-        "exitcode" | "stdout" | "stderr" => true,
-        _ => false,
-    }
+    matches!(clause, "exitcode" | "stdout" | "stderr")
 }
 
 /// Returns the command to bless a test file.


### PR DESCRIPTION
Currently, we determine on how a slide invocation should be emitted on
the application side, routing to `fmt::Display`, `fmt::Debug`, or
`Grammar#s_expr` accordingly. This won't scale very well, and in truth
our emission strategies should be the basis for other core rust traits
(like the `fmt` ones) implemented for the libslide IR.

This commit adds an `emit` module that provides an `EmitFormat` enum
replacing the existing `OutputForm` enum on the application side, and
exposes an `Emit` trait used to describe how a type can be emitted.
Eventually all types implementing `Emit` should implement all of its
member functions, but to ease migration, by default only `emit_pretty`
must be implemented.

The nice thing about this structure is that `fmt::Display` comes for
free if your type implements `emit_pretty`, and `emit_debug` comes for
free if your type implements `fmt::Debug`. Eventually, I would like to
reconcile the coupling between the `fmt` macros and `Emit` entirely,
maybe using a proc macro, but that is outside the scope of this change
and requires some forethought.

This work prepares for a LaTeX emit strategy (also low priority, but if
a new contributor would like to add it, this commit lays the groundwork
to make it easier).

Part of #162
