### PR TITLE
Add interner

### DIFF
--- a/libslide/Cargo.toml
+++ b/libslide/Cargo.toml
@@ -26,6 +26,8 @@ required-features = ["benchmark-internals"]
 
 [dependencies]
 strtod = "0.0.1"
+lasso = "0.3.1"
+lazy_static = "1.4.0"
 
 [dependencies.num-traits]
 version = "0.2"

--- a/libslide/src/emit.rs
+++ b/libslide/src/emit.rs
@@ -3,7 +3,6 @@
 use crate::grammar::*;
 
 use core::fmt;
-use std::rc::Rc;
 
 /// The format in which a slide grammar should be emitted.
 #[derive(Copy, Clone)]
@@ -94,7 +93,7 @@ macro_rules! fmt_emit_impl {
     ($S:path) => {
         impl core::fmt::Display for $S {
             fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-                write!(f, "{}", self.emit_pretty(),)
+                write!(f, "{}", self.emit_pretty())
             }
         }
     };
@@ -198,20 +197,6 @@ impl Emit for Expr {
     }
 }
 
-impl Emit for Rc<Expr> {
-    fn emit_pretty(&self) -> String {
-        self.as_ref().emit_pretty()
-    }
-
-    fn emit_s_expression(&self) -> String {
-        self.as_ref().emit_s_expression()
-    }
-
-    fn emit_latex(&self) -> String {
-        self.as_ref().emit_latex()
-    }
-}
-
 fmt_emit_impl!(BinaryOperator);
 impl Emit for BinaryOperator {
     fn emit_pretty(&self) -> String {
@@ -282,9 +267,9 @@ macro_rules! format_binary_operand {
 }
 
 macro_rules! display_binary_expr {
-    (<$expr:ident>) => {
-        fmt_emit_impl!(BinaryExpr<$expr>);
-        impl Emit for BinaryExpr<$expr> {
+    ($iexpr:ident, $expr:ident) => {
+        fmt_emit_impl!(BinaryExpr<$iexpr>);
+        impl Emit for BinaryExpr<$iexpr> {
             fn emit_pretty(&self) -> String {
                 format!(
                     "{} {} {}",
@@ -305,8 +290,8 @@ macro_rules! display_binary_expr {
         }
     };
 }
-display_binary_expr!(<Expr>);
-display_binary_expr!(<ExprPat>);
+display_binary_expr!(InternedExpr, Expr);
+display_binary_expr!(InternedExprPat, ExprPat);
 
 fmt_emit_impl!(UnaryOperator);
 impl Emit for UnaryOperator {
@@ -324,11 +309,11 @@ impl Emit for UnaryOperator {
 }
 
 macro_rules! display_unary_expr {
-    (<$expr:ident>) => {
-        fmt_emit_impl!(UnaryExpr<$expr>);
-        impl Emit for UnaryExpr<$expr> {
+    ($iexpr:ident, $expr:ident) => {
+        fmt_emit_impl!(UnaryExpr<$iexpr>);
+        impl Emit for UnaryExpr<$iexpr> {
             fn emit_pretty(&self) -> String {
-                let format_arg = |arg: &Rc<$expr>| match arg.as_ref() {
+                let format_arg = |arg: &$iexpr| match arg.as_ref() {
                     $expr::BinaryExpr(l) => format!("({})", l),
                     expr => expr.emit_pretty(),
                 };
@@ -336,7 +321,7 @@ macro_rules! display_unary_expr {
             }
 
             fn emit_latex(&self) -> String {
-                let format_arg = |arg: &Rc<$expr>| match arg.as_ref() {
+                let format_arg = |arg: &$iexpr| match arg.as_ref() {
                     $expr::BinaryExpr(l) => latex_wrap!((l)),
                     expr => expr.emit_latex(),
                 };
@@ -345,8 +330,8 @@ macro_rules! display_unary_expr {
         }
     };
 }
-display_unary_expr!(<Expr>);
-display_unary_expr!(<ExprPat>);
+display_unary_expr!(InternedExpr, Expr);
+display_unary_expr!(InternedExprPat, ExprPat);
 
 fmt_emit_impl!(ExprPat);
 impl Emit for ExprPat {
@@ -391,19 +376,5 @@ impl Emit for ExprPat {
             Self::Parend(inner) => latex_wrap!((inner.emit_latex())),
             Self::Bracketed(inner) => latex_wrap!([inner.emit_latex()]),
         }
-    }
-}
-
-impl Emit for Rc<ExprPat> {
-    fn emit_pretty(&self) -> String {
-        self.as_ref().emit_pretty()
-    }
-
-    fn emit_s_expression(&self) -> String {
-        self.as_ref().emit_s_expression()
-    }
-
-    fn emit_latex(&self) -> String {
-        self.as_ref().emit_latex()
     }
 }

--- a/libslide/src/evaluator_rules/registry/fn_rules.rs
+++ b/libslide/src/evaluator_rules/registry/fn_rules.rs
@@ -2,8 +2,6 @@ use crate::grammar::*;
 use crate::math::*;
 use crate::utils::*;
 
-use std::rc::Rc;
-
 macro_rules! get_binary_args {
     ($expr:expr, $op:pat) => {
         match $expr.as_ref() {
@@ -32,13 +30,13 @@ macro_rules! get_flattened_binary_args {
 macro_rules! get_unary_arg {
     ($expr:expr, $op:pat) => {
         match $expr.as_ref() {
-            Expr::UnaryExpr(UnaryExpr { op: $op, rhs }) => Some(rhs),
+            Expr::UnaryExpr(UnaryExpr { op: $op, rhs }) => Some(*rhs),
             _ => None,
         }
     };
 }
 
-pub(super) fn add(expr: Rc<Expr>) -> Option<Rc<Expr>> {
+pub(super) fn add(expr: InternedExpr) -> Option<InternedExpr> {
     let mut args = get_flattened_binary_args!(expr, BinaryOperator::Plus)?;
     let mut konst = 0.;
     let mut i = 0;
@@ -51,7 +49,7 @@ pub(super) fn add(expr: Rc<Expr>) -> Option<Rc<Expr>> {
             _ => i += 1,
         }
     }
-    args.push(Rc::new(konst.into()));
+    args.push(intern_expr!(konst.into()));
 
     Some(unflatten_binary_expr(
         &args,
@@ -60,12 +58,12 @@ pub(super) fn add(expr: Rc<Expr>) -> Option<Rc<Expr>> {
     ))
 }
 
-pub(super) fn subtract(expr: Rc<Expr>) -> Option<Rc<Expr>> {
+pub(super) fn subtract(expr: InternedExpr) -> Option<InternedExpr> {
     let (l, r) = get_binary_args!(expr, BinaryOperator::Minus)?;
-    Some(Rc::new(Expr::Const(l - r)))
+    Some(intern_expr!(Expr::Const(l - r)))
 }
 
-pub(super) fn multiply(expr: Rc<Expr>) -> Option<Rc<Expr>> {
+pub(super) fn multiply(expr: InternedExpr) -> Option<InternedExpr> {
     let mut args = get_flattened_binary_args!(expr, BinaryOperator::Mult)?;
     let mut konst = 1.;
     let mut i = 0;
@@ -78,7 +76,7 @@ pub(super) fn multiply(expr: Rc<Expr>) -> Option<Rc<Expr>> {
             _ => i += 1,
         }
     }
-    args.push(Rc::new(konst.into()));
+    args.push(intern_expr!(konst.into()));
 
     Some(unflatten_binary_expr(
         &args,
@@ -87,34 +85,34 @@ pub(super) fn multiply(expr: Rc<Expr>) -> Option<Rc<Expr>> {
     ))
 }
 
-pub(super) fn divide(expr: Rc<Expr>) -> Option<Rc<Expr>> {
+pub(super) fn divide(expr: InternedExpr) -> Option<InternedExpr> {
     match expr.as_ref() {
         Expr::BinaryExpr(BinaryExpr {
             op: BinaryOperator::Div,
             lhs,
             rhs,
         }) => match (lhs.as_ref(), rhs.as_ref()) {
-            (Expr::Const(l), Expr::Const(r)) => Some(Rc::new(Expr::Const(l / r))),
+            (Expr::Const(l), Expr::Const(r)) => Some(intern_expr!(Expr::Const(l / r))),
             _ => {
                 // Now we try to convert the numerator/denominator into polynomials and cancel them.
-                let (numerator, relative_to) = Poly::from_expr(lhs, None).ok()?;
+                let (numerator, relative_to) = Poly::from_expr(*lhs, None).ok()?;
                 let relative_to = match relative_to {
                     Some(e) => e,
                     // Cancelling should only work with term'd polynomials. If the expression has
                     // no terms for whatever reason, let another rule take care of it.
                     None => return None,
                 };
-                let (denominator, _) = Poly::from_expr(rhs, Some(&relative_to)).ok()?;
+                let (denominator, _) = Poly::from_expr(*rhs, Some(relative_to)).ok()?;
                 let (_, numerator, denominator) = gcd_poly_zz_heu(numerator, denominator).ok()?;
 
                 // Woo! The polynomials have a gcd we can cancel them with.
-                let numer_expr = numerator.to_expr(&relative_to);
+                let numer_expr = numerator.to_expr(relative_to);
                 if denominator.is_one() {
                     Some(numer_expr)
                 } else {
-                    let denom_expr = denominator.to_expr(&relative_to);
+                    let denom_expr = denominator.to_expr(relative_to);
                     let division = BinaryExpr::div(numer_expr, denom_expr);
-                    Some(Rc::new(Expr::BinaryExpr(division)))
+                    Some(intern_expr!(Expr::BinaryExpr(division)))
                 }
             }
         },
@@ -122,23 +120,23 @@ pub(super) fn divide(expr: Rc<Expr>) -> Option<Rc<Expr>> {
     }
 }
 
-pub(super) fn modulo(expr: Rc<Expr>) -> Option<Rc<Expr>> {
+pub(super) fn modulo(expr: InternedExpr) -> Option<InternedExpr> {
     let (l, r) = get_binary_args!(expr, BinaryOperator::Mod)?;
-    Some(Rc::new(Expr::Const(l % r)))
+    Some(intern_expr!(Expr::Const(l % r)))
 }
 
-pub(super) fn exponentiate(expr: Rc<Expr>) -> Option<Rc<Expr>> {
+pub(super) fn exponentiate(expr: InternedExpr) -> Option<InternedExpr> {
     let (l, r) = get_binary_args!(expr, BinaryOperator::Exp)?;
-    Some(Rc::new(Expr::Const(l.powf(*r))))
+    Some(intern_expr!(Expr::Const(l.powf(*r))))
 }
 
-pub(super) fn posate(expr: Rc<Expr>) -> Option<Rc<Expr>> {
-    get_unary_arg!(expr, UnaryOperator::SignPositive).map(Rc::clone)
+pub(super) fn posate(expr: InternedExpr) -> Option<InternedExpr> {
+    get_unary_arg!(expr, UnaryOperator::SignPositive)
 }
 
-pub(super) fn negate(expr: Rc<Expr>) -> Option<Rc<Expr>> {
+pub(super) fn negate(expr: InternedExpr) -> Option<InternedExpr> {
     match get_unary_arg!(expr, UnaryOperator::SignNegative)?.as_ref() {
-        Expr::Const(n) => Some(Rc::new(Expr::Const(-n))),
+        Expr::Const(n) => Some(intern_expr!(Expr::Const(-n))),
         _ => None,
     }
 }

--- a/libslide/src/evaluator_rules/unbuilt_rule.rs
+++ b/libslide/src/evaluator_rules/unbuilt_rule.rs
@@ -1,6 +1,4 @@
-use crate::grammar::Expr;
-
-use std::rc::Rc;
+use crate::grammar::InternedExpr;
 
 /// An unbuilt rule, generally used to express a rule in a human-readable form.
 #[derive(Copy, Clone)]
@@ -44,7 +42,7 @@ pub enum UnbuiltRule {
     M(&'static [&'static str]),
 
     /// A function rule.
-    F(fn(Rc<Expr>) -> Option<Rc<Expr>>),
+    F(fn(InternedExpr) -> Option<InternedExpr>),
 }
 
 impl From<&'static str> for UnbuiltRule {

--- a/libslide/src/grammar/intern.rs
+++ b/libslide/src/grammar/intern.rs
@@ -1,0 +1,212 @@
+//! Provides interners for slide [Grammar]s.
+//! An interned slide [Grammar] is itself a [Grammar] for convenience of use.
+//!
+//! [Grammar]: super::Grammar
+
+use crate::emit::Emit;
+use crate::grammar::{Expr, ExprPat, Grammar};
+
+use core::cmp::Ordering;
+use lasso::{Rodeo, Spur};
+use lazy_static::lazy_static;
+use std::collections::HashMap;
+use std::ops::Deref;
+use std::sync::RwLock;
+
+/// Describes an interned slide expression.
+pub trait InternedExpression
+where
+    Self: Copy + Deref + Ord + From<super::BinaryExpr<Self>> + From<super::UnaryExpr<Self>>,
+{
+    type Inner;
+
+    /// Returns whether the expression is a statically-evaluatable constant.
+    fn is_const(&self) -> bool;
+
+    /// Paranthesizes `inner`.
+    fn paren(inner: Self) -> Self;
+
+    /// Brackets `inner`.
+    fn bracket(inner: Self) -> Self;
+
+    /// Returns an empty expression.
+    fn empty() -> Self;
+}
+
+macro_rules! make_interner {
+    ($($intern_macro:ident, $ty:ty, $interned_struct:ident, $rodeo:ident, $spur2expr:ident)*) => {$(
+        lazy_static! {
+            // Why two intern tables? The idea is to hash a grammar to a string, intern the string
+            // in Rodeo, and keep a table mapping the interned string reference to the original
+            // grammar. Rodeo provides fast lookups, so the largest constraint here is creating the
+            // string hash from a grammar.
+            //
+            // Okay, but why not just a Map<Grammar, Grammar>? This doesn't quite work because then
+            // we need to store &Grammar on the interned struct, which needs a lifetime. The only
+            // lifetime that would work non-locally is 'static, but that is longer than the
+            // lifetime of variables declared via lazy_static.
+            //
+            // Okay, but why not just a Map<String, Grammar>? Because then we must store a string
+            // on the interned struct, and clone a string anytime we intern a value (even if it
+            // already exists). This is much more expensive than a reference or 32-bit Spur.
+            static ref $rodeo: RwLock<Rodeo<Spur>> = RwLock::new(Rodeo::default());
+            static ref $spur2expr: RwLock<HashMap<Spur, $ty>> = RwLock::new(HashMap::new());
+        }
+
+        /// An interned version of an expression.
+        #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+        pub struct $interned_struct(pub(crate) Spur);
+
+        impl $interned_struct {
+            /// Interns the expression, or returns the existing interned reference if it already
+            /// exists.
+            pub(crate) fn intern(expr: $ty) -> Self {
+                let hash = expr.emit_s_expression();
+                let mb = $rodeo
+                    .read()
+                    .expect("Failed to read intern rodeo; likely poisoned.")
+                    .get(hash);
+                match mb {
+                    Some(spur) => Self(spur),
+                    None => {
+                        let spur = $rodeo
+                            .write()
+                            .expect("Failed to write to intern rodeo; likely poisoned.")
+                            .get_or_intern(expr.emit_s_expression());
+                        $spur2expr
+                            .write()
+                            .expect("Failed to write to intern reverse map; likely poisoned.")
+                            .insert(spur, expr);
+                        Self(spur)
+                    }
+                }
+            }
+        }
+
+        /// Interns an expression.
+        #[doc(hidden)]
+        #[macro_export]
+        macro_rules! $intern_macro {
+            ($expr: expr) => {
+                $interned_struct::intern($expr)
+            }
+        }
+
+        impl Grammar for $interned_struct {}
+
+        impl Emit for $interned_struct {
+            fn emit_pretty(&self) -> String {
+                self.as_ref().emit_pretty()
+            }
+
+            fn emit_s_expression(&self) -> String {
+                self.as_ref().emit_s_expression()
+            }
+
+            fn emit_latex(&self) -> String {
+                self.as_ref().emit_latex()
+            }
+        }
+
+        impl core::fmt::Display for $interned_struct {
+            fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                write!(f, "{}", self.emit_pretty(),)
+            }
+        }
+
+        impl AsRef<$ty> for $interned_struct {
+            fn as_ref(&self) -> &$ty {
+                self.deref()
+            }
+        }
+
+        impl Deref for $interned_struct {
+            type Target = <Self as InternedExpression>::Inner;
+
+            fn deref(&self) -> &<Self as InternedExpression>::Inner {
+                let table = $spur2expr.read().expect("Failed to read intern reverse map; likely poisoned.");
+                let val = table.get(&self.0).expect("BUG: intern key does not map to an interned value");
+                // Safety:
+                // - semantics: OK because cast to ptr, then deref ptr and return reference
+                // - lifetimes: OK because values present in the intern tables last for the lifetime
+                //   of the table, which is static.
+                unsafe {
+                    &*(val as *const $ty)
+                }
+            }
+        }
+
+        impl PartialOrd for $interned_struct {
+            fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+                Some(self.cmp(other))
+            }
+        }
+
+        impl Ord for $interned_struct {
+            fn cmp(&self, other: &Self) -> Ordering {
+                self.as_ref().cmp(&other.as_ref())
+            }
+        }
+
+        impl From<$ty> for $interned_struct {
+            fn from(expr: $ty) -> Self {
+                $intern_macro!(expr)
+            }
+        }
+    )*};
+}
+
+make_interner! {
+    intern_expr, Expr, InternedExpr, EXPR_RODEO, SPUR2EXPR
+    intern_expr_pat, ExprPat, InternedExprPat, EXPR_PAT_RODEO, SPUR2EXPR_PAT
+}
+
+impl InternedExpression for InternedExpr {
+    type Inner = Expr;
+
+    #[inline]
+    fn is_const(&self) -> bool {
+        matches!(**self, Expr::Const(_))
+    }
+
+    #[inline]
+    fn paren(inner: InternedExpr) -> Self {
+        intern_expr!(Expr::Parend(inner))
+    }
+
+    #[inline]
+    fn bracket(inner: InternedExpr) -> Self {
+        intern_expr!(Expr::Bracketed(inner))
+    }
+
+    #[inline]
+    fn empty() -> Self {
+        // Variables must be named, so we can encode an unnamed variable as an empty expression.
+        intern_expr!(Expr::Var(String::new()))
+    }
+}
+
+impl InternedExpression for InternedExprPat {
+    type Inner = ExprPat;
+
+    #[inline]
+    fn is_const(&self) -> bool {
+        matches!(**self, ExprPat::Const(_))
+    }
+
+    #[inline]
+    fn paren(inner: InternedExprPat) -> Self {
+        intern_expr_pat!(ExprPat::Parend(inner))
+    }
+
+    #[inline]
+    fn bracket(inner: InternedExprPat) -> Self {
+        intern_expr_pat!(ExprPat::Bracketed(inner))
+    }
+
+    #[inline]
+    fn empty() -> Self {
+        // Patterns must be named, so we can encode an unnamed pattern as an empty expression.
+        intern_expr_pat!(ExprPat::VarPat(String::new()))
+    }
+}

--- a/libslide/src/grammar/pattern.rs
+++ b/libslide/src/grammar/pattern.rs
@@ -1,6 +1,4 @@
-pub use super::*;
-
-use std::rc::Rc;
+use super::*;
 
 #[derive(Clone, Debug)]
 pub enum ExprPat {
@@ -11,37 +9,13 @@ pub enum ExprPat {
     ConstPat(String),
     /// Pattern matching any expression
     AnyPat(String),
-    BinaryExpr(BinaryExpr<Self>),
-    UnaryExpr(UnaryExpr<Self>),
-    Parend(Rc<Self>),
-    Bracketed(Rc<Self>),
+    BinaryExpr(BinaryExpr<InternedExprPat>),
+    UnaryExpr(UnaryExpr<InternedExprPat>),
+    Parend(InternedExprPat),
+    Bracketed(InternedExprPat),
 }
 
 impl Grammar for ExprPat {}
-impl Grammar for Rc<ExprPat> {}
-
-impl Expression for ExprPat {
-    #[inline]
-    fn is_const(&self) -> bool {
-        matches!(self, Self::Const(_))
-    }
-
-    #[inline]
-    fn paren(inner: Rc<Self>) -> Self {
-        Self::Parend(inner)
-    }
-
-    #[inline]
-    fn bracket(inner: Rc<Self>) -> Self {
-        Self::Bracketed(inner)
-    }
-
-    #[inline]
-    fn empty() -> Self {
-        // Patterns must be named, so we can encode an unnamed pattern as an empty expression.
-        ExprPat::VarPat(String::new())
-    }
-}
 
 // TODO: We can't derive this because `f64` doesn't implement `Eq`.
 // This should be fixed by moving to a arbitrary-precision numeric type.
@@ -83,15 +57,15 @@ impl core::hash::Hash for ExprPat {
     }
 }
 
-impl From<BinaryExpr<Self>> for ExprPat {
-    fn from(binary_expr: BinaryExpr<Self>) -> Self {
-        Self::BinaryExpr(binary_expr)
+impl From<BinaryExpr<InternedExprPat>> for InternedExprPat {
+    fn from(binary_expr: BinaryExpr<InternedExprPat>) -> Self {
+        intern_expr_pat!(ExprPat::BinaryExpr(binary_expr))
     }
 }
 
-impl From<UnaryExpr<Self>> for ExprPat {
-    fn from(unary_expr: UnaryExpr<Self>) -> Self {
-        Self::UnaryExpr(unary_expr)
+impl From<UnaryExpr<InternedExprPat>> for InternedExprPat {
+    fn from(unary_expr: UnaryExpr<InternedExprPat>) -> Self {
+        intern_expr_pat!(ExprPat::UnaryExpr(unary_expr))
     }
 }
 

--- a/libslide/src/lib.rs
+++ b/libslide/src/lib.rs
@@ -199,6 +199,10 @@
     html_logo_url = "https://avatars1.githubusercontent.com/u/49662722?s=400&u=62119505c71017e88a2728f7a1257b3506481441&v=4"
 )]
 
+#[macro_use]
+mod grammar;
+pub use grammar::Grammar;
+
 mod common;
 pub use common::*;
 
@@ -216,8 +220,6 @@ pub use partial_evaluator::evaluate;
 pub use partial_evaluator::EvaluatorContext;
 
 mod evaluator_rules;
-mod grammar;
-pub use grammar::Grammar;
 
 mod math;
 

--- a/libslide/src/parser/expression_parser.rs
+++ b/libslide/src/parser/expression_parser.rs
@@ -3,10 +3,7 @@ use crate::common::Span;
 use crate::diagnostics::Diagnostic;
 use crate::grammar::*;
 use crate::scanner::types::{Token, TokenType};
-use crate::utils::{hash, PeekIter, StringUtils};
-
-use std::collections::HashMap;
-use std::rc::Rc;
+use crate::utils::{PeekIter, StringUtils};
 
 /// Parses a tokenized slide program, emitting the result and any diagnostics.
 pub fn parse(input: Vec<Token>) -> (Stmt, Vec<Diagnostic>) {
@@ -17,10 +14,6 @@ pub fn parse(input: Vec<Token>) -> (Stmt, Vec<Diagnostic>) {
 pub struct ExpressionParser {
     _input: PeekIter<Token>,
     diagnostics: Vec<Diagnostic>,
-    // We use an untyped hash here because we don't want to clone an Expr into the map in case it's
-    // already there when using an entry API.
-    // TODO: replace with Expr when raw_entry API is stabilized (see rust#56167)
-    seen: HashMap<u64, Rc<Expr>>,
 }
 
 impl ExpressionParser {
@@ -33,7 +26,7 @@ impl ExpressionParser {
 }
 
 impl ExpressionParser {
-    fn parse_pattern(&mut self, name: String, span: Span) -> Expr {
+    fn parse_pattern(&mut self, name: String, span: Span) -> InternedExpr {
         self.push_diag(
             Diagnostic::span_err(
                 span,
@@ -45,18 +38,17 @@ impl ExpressionParser {
                 cut_name = name.substring(1, name.len() - 1)
             )),
         );
-        Expr::Var(name)
+        intern_expr!(Expr::Var(name))
     }
 }
 
 impl Parser<Stmt> for ExpressionParser {
-    type Expr = Expr;
+    type Expr = InternedExpr;
 
     fn new(input: Vec<Token>) -> Self {
         Self {
             _input: PeekIter::new(input.into_iter()),
             diagnostics: vec![],
-            seen: HashMap::new(),
         }
     }
 
@@ -76,7 +68,7 @@ impl Parser<Stmt> for ExpressionParser {
                 self.input().next();
                 self.assignment(name)
             }
-            _ => Stmt::Expr((*self.expr()).clone()),
+            _ => Stmt::Expr(self.expr()),
         };
         if !self.done() {
             let extra_tokens_diag = extra_tokens_diag(self.input());
@@ -86,11 +78,11 @@ impl Parser<Stmt> for ExpressionParser {
     }
 
     fn parse_float(&mut self, f: f64, _span: Span) -> Self::Expr {
-        Self::Expr::Const(f)
+        intern_expr!(Expr::Const(f))
     }
 
     fn parse_variable(&mut self, name: String, _span: Span) -> Self::Expr {
-        Expr::Var(name)
+        intern_expr!(Expr::Var(name))
     }
 
     fn parse_var_pattern(&mut self, name: String, span: Span) -> Self::Expr {
@@ -104,21 +96,10 @@ impl Parser<Stmt> for ExpressionParser {
     fn parse_any_pattern(&mut self, name: String, span: Span) -> Self::Expr {
         self.parse_pattern(name, span)
     }
-
-    fn finish_expr(&mut self, expr: Self::Expr) -> Rc<Self::Expr> {
-        let p = self
-            .seen
-            .entry(hash(&expr))
-            .or_insert_with(|| Rc::new(expr));
-        Rc::clone(p)
-    }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use crate::scan;
-
     parser_tests! {
         parse_expression
 
@@ -127,31 +108,5 @@ mod tests {
         variable_in_op_right:    "1 + a"
         assignment_op:           "a = 5"
         assignment_op_expr:      "a = 5 + 2 ^ 3"
-    }
-
-    #[test]
-    fn common_subexpression_elimination() {
-        let program = "1 * 2 + 1 * 2";
-        let tokens = scan(program).tokens;
-        let (parsed, _) = parse(tokens);
-        let (l, r) = match parsed {
-            Stmt::Expr(Expr::BinaryExpr(BinaryExpr { lhs, rhs, .. })) => (lhs, rhs),
-            _ => unreachable!(),
-        };
-        assert!(std::ptr::eq(l.as_ref(), r.as_ref())); // 1 * 2
-
-        let (ll, lr, rl, rr) = match (l.as_ref(), r.as_ref()) {
-            (
-                Expr::BinaryExpr(BinaryExpr {
-                    lhs: ll, rhs: lr, ..
-                }),
-                Expr::BinaryExpr(BinaryExpr {
-                    lhs: rl, rhs: rr, ..
-                }),
-            ) => (ll, lr, rl, rr),
-            _ => unreachable!(),
-        };
-        assert!(std::ptr::eq(ll.as_ref(), rl.as_ref())); // 1
-        assert!(std::ptr::eq(lr.as_ref(), rr.as_ref())); // 2
     }
 }

--- a/libslide/src/parser/expression_pattern_parser.rs
+++ b/libslide/src/parser/expression_pattern_parser.rs
@@ -3,13 +3,10 @@ use crate::common::Span;
 use crate::diagnostics::Diagnostic;
 use crate::grammar::*;
 use crate::scanner::types::Token;
-use crate::utils::{hash, PeekIter};
-
-use std::collections::HashMap;
-use std::rc::Rc;
+use crate::utils::PeekIter;
 
 /// Parses a tokenized slide expression pattern, emitting the result and any diagnostics.
-pub fn parse(input: Vec<Token>) -> (Rc<ExprPat>, Vec<Diagnostic>) {
+pub fn parse(input: Vec<Token>) -> (InternedExprPat, Vec<Diagnostic>) {
     let mut parser = ExpressionPatternParser::new(input);
     (parser.parse(), parser.diagnostics)
 }
@@ -17,20 +14,15 @@ pub fn parse(input: Vec<Token>) -> (Rc<ExprPat>, Vec<Diagnostic>) {
 pub struct ExpressionPatternParser {
     _input: PeekIter<Token>,
     diagnostics: Vec<Diagnostic>,
-    // We use an untyped hash here because we don't want to clone an Expr into the map in case it's
-    // already there when using an entry API.
-    // TODO: replace with Expr when raw_entry API is stabilized (see rust#56167)
-    seen: HashMap<u64, Rc<ExprPat>>,
 }
 
-impl Parser<Rc<ExprPat>> for ExpressionPatternParser {
-    type Expr = ExprPat;
+impl Parser<InternedExprPat> for ExpressionPatternParser {
+    type Expr = InternedExprPat;
 
     fn new(input: Vec<Token>) -> Self {
         Self {
             _input: PeekIter::new(input.into_iter()),
             diagnostics: vec![],
-            seen: HashMap::new(),
         }
     }
 
@@ -42,7 +34,7 @@ impl Parser<Rc<ExprPat>> for ExpressionPatternParser {
         self.diagnostics.push(diagnostic);
     }
 
-    fn parse(&mut self) -> Rc<ExprPat> {
+    fn parse(&mut self) -> InternedExprPat {
         let parsed = self.expr();
         if !self.done() {
             let extra_tokens_diag = extra_tokens_diag(self.input());
@@ -52,7 +44,7 @@ impl Parser<Rc<ExprPat>> for ExpressionPatternParser {
     }
 
     fn parse_float(&mut self, f: f64, _span: Span) -> Self::Expr {
-        Self::Expr::Const(f)
+        intern_expr_pat!(ExprPat::Const(f))
     }
 
     fn parse_variable(&mut self, name: String, span: Span) -> Self::Expr {
@@ -67,27 +59,19 @@ impl Parser<Rc<ExprPat>> for ExpressionPatternParser {
                 name = name,
             )),
         );
-        Self::Expr::VarPat(name)
+        intern_expr_pat!(ExprPat::VarPat(name))
     }
 
     fn parse_var_pattern(&mut self, name: String, _span: Span) -> Self::Expr {
-        Self::Expr::VarPat(name)
+        intern_expr_pat!(ExprPat::VarPat(name))
     }
 
     fn parse_const_pattern(&mut self, name: String, _span: Span) -> Self::Expr {
-        Self::Expr::ConstPat(name)
+        intern_expr_pat!(ExprPat::ConstPat(name))
     }
 
     fn parse_any_pattern(&mut self, name: String, _span: Span) -> Self::Expr {
-        Self::Expr::AnyPat(name)
-    }
-
-    fn finish_expr(&mut self, expr: Self::Expr) -> Rc<Self::Expr> {
-        let p = self
-            .seen
-            .entry(hash(&expr))
-            .or_insert_with(|| Rc::new(expr));
-        Rc::clone(p)
+        intern_expr_pat!(ExprPat::AnyPat(name))
     }
 }
 

--- a/libslide/src/utils/grammar.rs
+++ b/libslide/src/utils/grammar.rs
@@ -1,22 +1,21 @@
 use crate::grammar::*;
 
 use std::collections::{HashSet, VecDeque};
-use std::rc::Rc;
 
-pub fn get_symmetric_expressions(expr: Rc<Expr>) -> Vec<Rc<Expr>> {
+pub fn get_symmetric_expressions(expr: InternedExpr) -> Vec<InternedExpr> {
     match expr.as_ref() {
         Expr::BinaryExpr(BinaryExpr { op, .. }) => match op {
             BinaryOperator::Plus | BinaryOperator::Mult => {
-                let args = get_flattened_binary_args(Rc::clone(&expr), *op);
+                let args = get_flattened_binary_args(expr, *op);
                 let mut sym_args = Vec::with_capacity(args.len());
                 let mut result = Vec::with_capacity((args.len() - 1) * 2);
                 for i in 0..args.len() {
-                    sym_args.push(Rc::clone(&args[i]));
+                    sym_args.push(args[i]);
                     for arg in args.iter().take(i) {
-                        sym_args.push(Rc::clone(arg));
+                        sym_args.push(*arg);
                     }
                     for arg in args.iter().skip(i + 1) {
-                        sym_args.push(Rc::clone(arg));
+                        sym_args.push(*arg);
                     }
                     result.push(unflatten_binary_expr(
                         &sym_args,
@@ -52,7 +51,10 @@ macro_rules! insert_back {
     };
 }
 
-pub fn get_flattened_binary_args(expr: Rc<Expr>, parent_op: BinaryOperator) -> Vec<Rc<Expr>> {
+pub fn get_flattened_binary_args(
+    expr: InternedExpr,
+    parent_op: BinaryOperator,
+) -> Vec<InternedExpr> {
     match expr.as_ref() {
         Expr::BinaryExpr(
             child
@@ -64,8 +66,8 @@ pub fn get_flattened_binary_args(expr: Rc<Expr>, parent_op: BinaryOperator) -> V
         ) if parent_op == BinaryOperator::Plus => {
             // ... + ((1 + 2) + (3 + 4)) => ... + 1, 2, 3, 4
             let mut args = VecDeque::with_capacity(2);
-            let flattened_left = get_flattened_binary_args(Rc::clone(&child.lhs), child.op);
-            let flattened_right = get_flattened_binary_args(Rc::clone(&child.rhs), child.op);
+            let flattened_left = get_flattened_binary_args(child.lhs, child.op);
+            let flattened_right = get_flattened_binary_args(child.rhs, child.op);
             insert_front!(args, flattened_left);
             insert_back!(args, flattened_right);
             args.into_iter().collect()
@@ -81,8 +83,8 @@ pub fn get_flattened_binary_args(expr: Rc<Expr>, parent_op: BinaryOperator) -> V
         ) if parent_op == BinaryOperator::Mult => {
             // ... * ((1 * 2) * (3 * 4)) => ... * 1, 2, 3, 4
             let mut args = VecDeque::with_capacity(2);
-            let flattened_left = get_flattened_binary_args(Rc::clone(&child.lhs), child.op);
-            let flattened_right = get_flattened_binary_args(Rc::clone(&child.rhs), child.op);
+            let flattened_left = get_flattened_binary_args(child.lhs, child.op);
+            let flattened_right = get_flattened_binary_args(child.rhs, child.op);
             insert_front!(args, flattened_left);
             insert_back!(args, flattened_right);
             args.into_iter().collect()
@@ -99,8 +101,8 @@ pub fn get_flattened_binary_args(expr: Rc<Expr>, parent_op: BinaryOperator) -> V
             // ... + (2 - 3) => ... + 2, -3
             // ... + ((1 + 2) - (2 + 3)) => ... + 1, 2, -2, -3
             let mut args = VecDeque::with_capacity(2);
-            let flattened_left = get_flattened_binary_args(Rc::clone(&child.lhs), child.op);
-            let flattened_right = get_flattened_binary_args(Rc::clone(&child.rhs), child.op);
+            let flattened_left = get_flattened_binary_args(child.lhs, child.op);
+            let flattened_right = get_flattened_binary_args(child.rhs, child.op);
             insert_front!(args, flattened_left);
             insert_back!(args, flattened_right.into_iter().map(negate));
             args.into_iter().collect()
@@ -109,45 +111,42 @@ pub fn get_flattened_binary_args(expr: Rc<Expr>, parent_op: BinaryOperator) -> V
     }
 }
 
-fn negate(expr: Rc<Expr>) -> Rc<Expr> {
+fn negate(expr: InternedExpr) -> InternedExpr {
     match expr.as_ref() {
         // #a -> -#a
-        Expr::Const(f) => Expr::Const(-f).into(),
+        Expr::Const(f) => intern_expr!(Expr::Const(-f)),
 
         // $a -> -$a
-        Expr::Var(_) => Expr::UnaryExpr(UnaryExpr {
+        Expr::Var(_) => intern_expr!(Expr::UnaryExpr(UnaryExpr {
             op: UnaryOperator::SignNegative,
             rhs: expr,
-        })
-        .into(),
+        })),
 
         // +_a => -_a
         Expr::UnaryExpr(UnaryExpr {
             op: UnaryOperator::SignPositive,
             rhs,
-        }) => Expr::UnaryExpr(UnaryExpr {
+        }) => intern_expr!(Expr::UnaryExpr(UnaryExpr {
             op: UnaryOperator::SignPositive,
-            rhs: Rc::clone(rhs),
-        })
-        .into(),
+            rhs: *rhs,
+        })),
 
         // -_a => _a
         Expr::UnaryExpr(UnaryExpr {
             op: UnaryOperator::SignNegative,
             rhs,
-        }) => Rc::clone(rhs),
+        }) => *rhs,
 
         // _a <op> _b => -(_a <op> _b)
         // TODO: We could expand factorable expressions further:
         //       -(_a + _b) = -_a + -_b
         //       -(_a - _b) = -_a - -_b
-        Expr::BinaryExpr(_) => Expr::UnaryExpr(UnaryExpr {
+        Expr::BinaryExpr(_) => intern_expr!(Expr::UnaryExpr(UnaryExpr {
             op: UnaryOperator::SignNegative,
-            rhs: Rc::clone(&expr),
-        })
-        .into(),
+            rhs: expr,
+        })),
 
-        Expr::Parend(expr) | Expr::Bracketed(expr) => negate(Rc::clone(expr)),
+        Expr::Parend(expr) | Expr::Bracketed(expr) => negate(*expr),
     }
 }
 
@@ -156,42 +155,24 @@ pub enum UnflattenStrategy {
     Right, // (+ 1 (+ 2 3))
 }
 
-pub fn unflatten_binary_expr<E>(
-    args: &[Rc<E>],
-    op: BinaryOperator,
-    strategy: UnflattenStrategy,
-) -> Rc<E>
+pub fn unflatten_binary_expr<E>(args: &[E], op: BinaryOperator, strategy: UnflattenStrategy) -> E
 where
-    E: Expression,
+    E: InternedExpression,
 {
-    fn _left<E: Expression>(args: &[Rc<E>], op: BinaryOperator) -> Rc<E> {
+    fn _left<E: InternedExpression>(args: &[E], op: BinaryOperator) -> E {
         let mut args = args.iter();
-        let mut lhs = Rc::clone(args.next().unwrap());
+        let mut lhs = *args.next().unwrap();
         for rhs in args {
-            lhs = Rc::new(
-                BinaryExpr {
-                    op,
-                    lhs,
-                    rhs: Rc::clone(rhs),
-                }
-                .into(),
-            );
+            lhs = BinaryExpr { op, lhs, rhs: *rhs }.into();
         }
         lhs
     }
 
-    fn _right<E: Expression>(args: &[Rc<E>], op: BinaryOperator) -> Rc<E> {
+    fn _right<E: InternedExpression>(args: &[E], op: BinaryOperator) -> E {
         let mut args = args.iter().rev();
-        let mut rhs = Rc::clone(args.next().unwrap());
+        let mut rhs = *args.next().unwrap();
         for lhs in args {
-            rhs = Rc::new(
-                BinaryExpr {
-                    op,
-                    lhs: Rc::clone(lhs),
-                    rhs,
-                }
-                .into(),
-            );
+            rhs = BinaryExpr { op, lhs: *lhs, rhs }.into();
         }
         rhs
     }
@@ -203,8 +184,8 @@ where
 }
 
 /// Returns all unique patterns in a pattern expression.
-pub fn unique_pats<'a>(expr: &'a Rc<ExprPat>) -> HashSet<&'a Rc<ExprPat>> {
-    fn unique_pats<'a>(expr: &'a Rc<ExprPat>, set: &mut HashSet<&'a Rc<ExprPat>>) {
+pub fn unique_pats<'a>(expr: &'a InternedExprPat) -> HashSet<&'a InternedExprPat> {
+    fn unique_pats<'a>(expr: &'a InternedExprPat, set: &mut HashSet<&'a InternedExprPat>) {
         match expr.as_ref() {
             ExprPat::VarPat(_) | ExprPat::ConstPat(_) | ExprPat::AnyPat(_) => {
                 set.insert(expr);
@@ -228,30 +209,29 @@ pub fn unique_pats<'a>(expr: &'a Rc<ExprPat>) -> HashSet<&'a Rc<ExprPat>> {
     hs
 }
 
-pub fn normalize(expr: Rc<Expr>) -> Rc<Expr> {
+pub fn normalize(expr: InternedExpr) -> InternedExpr {
     match expr.as_ref() {
         Expr::BinaryExpr(BinaryExpr { op, lhs, rhs }) => {
             let partially_normalized = Expr::BinaryExpr(BinaryExpr {
                 op: *op,
-                lhs: normalize(Rc::clone(lhs)),
-                rhs: normalize(Rc::clone(rhs)),
+                lhs: normalize(*lhs),
+                rhs: normalize(*rhs),
             });
             let mut flattened_args = get_flattened_binary_args(partially_normalized.into(), *op);
             flattened_args.sort();
             unflatten_binary_expr(&flattened_args, *op, UnflattenStrategy::Left)
         }
-        Expr::UnaryExpr(UnaryExpr { op, rhs }) => Expr::UnaryExpr(UnaryExpr {
+        Expr::UnaryExpr(UnaryExpr { op, rhs }) => intern_expr!(Expr::UnaryExpr(UnaryExpr {
             op: *op,
-            rhs: normalize(Rc::clone(rhs)),
-        })
-        .into(),
+            rhs: normalize(*rhs),
+        })),
         Expr::Parend(expr) => {
-            let inner = normalize(Rc::clone(expr));
-            Expr::Parend(inner).into()
+            let inner = normalize(*expr);
+            intern_expr!(Expr::Parend(inner))
         }
         Expr::Bracketed(expr) => {
-            let inner = normalize(Rc::clone(expr));
-            Expr::Bracketed(inner).into()
+            let inner = normalize(*expr);
+            intern_expr!(Expr::Bracketed(inner))
         }
 
         _ => expr,
@@ -263,10 +243,10 @@ mod tests {
     use super::*;
     use crate::{parse_expression, parse_expression_pattern, scan};
 
-    fn parse(s: &'static str) -> Rc<Expr> {
+    fn parse(s: &'static str) -> InternedExpr {
         let toks = scan(s).tokens;
         match parse_expression(toks) {
-            (Stmt::Expr(expr), _) => Rc::new(expr),
+            (Stmt::Expr(expr), _) => expr,
             _ => unreachable!(),
         }
     }
@@ -334,7 +314,7 @@ mod tests {
 
     #[test]
     fn unflatten_binary_expr_right() {
-        let args: Vec<Rc<Expr>> = vec!["1", "2", "3", "4"].into_iter().map(parse).collect();
+        let args: Vec<InternedExpr> = vec!["1", "2", "3", "4"].into_iter().map(parse).collect();
         let expr = unflatten_binary_expr(&args, BinaryOperator::Plus, UnflattenStrategy::Right);
 
         match expr.as_ref() {
@@ -365,7 +345,7 @@ mod tests {
 
     #[test]
     fn unflatten_binary_expr_left() {
-        let args: Vec<Rc<Expr>> = vec!["1", "2", "3", "4"].into_iter().map(parse).collect();
+        let args: Vec<InternedExpr> = vec!["1", "2", "3", "4"].into_iter().map(parse).collect();
         let expr = unflatten_binary_expr(&args, BinaryOperator::Plus, UnflattenStrategy::Left);
 
         match expr.as_ref() {

--- a/libslide/src/utils/test.rs
+++ b/libslide/src/utils/test.rs
@@ -9,7 +9,7 @@ macro_rules! parse_expr {
         let tokens = scan($expr).tokens;
         let (parsed, _) = parse_expression(tokens);
         match parsed {
-            Stmt::Expr(expr) => Rc::new(expr),
+            Stmt::Expr(expr) => expr,
             _ => unreachable!(),
         }
     }};

--- a/slide/src/test/ui/emit/debug.slide
+++ b/slide/src/test/ui/emit/debug.slide
@@ -9,31 +9,9 @@
 
 ~~~stdout
 Expr(
-    BinaryExpr(
-        BinaryExpr {
-            op: Plus,
-            lhs: BinaryExpr(
-                BinaryExpr {
-                    op: Plus,
-                    lhs: Const(
-                        1.0,
-                    ),
-                    rhs: BinaryExpr(
-                        BinaryExpr {
-                            op: Div,
-                            lhs: Const(
-                                5.0,
-                            ),
-                            rhs: Const(
-                                10.0,
-                            ),
-                        },
-                    ),
-                },
-            ),
-            rhs: Const(
-                2.0,
-            ),
+    InternedExpr(
+        Spur {
+            key: 7,
         },
     ),
 )


### PR DESCRIPTION
This commit adds an interner for slide Grammars. See
libslide/src/grammar/intern.rs for more details. The purpose of this is
to reduce duplication of grammar instances that already exist by
aggregating all instances in a common pool, and returning an opaque
reference to the instance rather than the instance directly. Operations
on the instance can still be done through the intern reference via
dereferences or methods on traits common to Grammars.

The intern strategy is

```
Grammar -> String Hash -> 32-bit identifier
^^^^^^^                   ^^^^^^^^^^^^^^^^^
instance                 interned reference
```

The 32-bit identifier is then mapped back to a Grammar when we need to
dereference it.

Closes #101