### PR TITLE
Fix superfluous fuzzing failures

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -75,7 +75,7 @@ jobs:
             Daily slide fuzzing failed. Last 30 lines of the output log are as follows:
 
             ```
-            ${{ fromJson(steps.run.outputs.matrix).fuzz_out }}
+            ${{ fromJson(steps.run.outputs.matrix).out }}
             ```
 
             Download this test case at ${{ fromJson(steps.run.outputs.matrix).dl_case }}

--- a/slide/fuzz/fuzz_targets/slide.rs
+++ b/slide/fuzz/fuzz_targets/slide.rs
@@ -11,8 +11,8 @@ fuzz_target!(|program: String| {
     cmd.arg("--");
     cmd.arg(&program);
 
-    match cmd.output().unwrap().status.code().unwrap() {
-        2 => panic!("Failed!"),
+    match cmd.output().ok().and_then(|out| out.status.code()) {
+        Some(2) => panic!("Failed!"),
         _ => {}
     }
 });


### PR DESCRIPTION
- We only want to panic when the exit code is 2, not for any other
  reason (like the process had an output will a null byte)
- Print output, not the fuzz file

Closes #198
