### PR TITLE
Add support for spans on expressions

### DIFF
--- a/libslide/src/common.rs
+++ b/libslide/src/common.rs
@@ -3,12 +3,30 @@
 /// Describes the character span of a substring in a text.
 ///
 /// For example, in "abcdef", "bcd" has the span (1, 4).
-#[derive(PartialEq, Eq, Copy, Clone, Debug)]
+#[derive(PartialEq, Eq, Copy, Clone, Debug, Hash)]
 pub struct Span {
     /// Inclusive lower bound index of the span
     pub lo: usize,
     /// Exclusive upper bound index of the span
     pub hi: usize,
+}
+
+/// A dummy span for use in places where a span is not (yet) known.
+///
+/// Clearly this span is incorrect since lo = 10001 > 1 = hi, but a well-formed span must observe
+/// the invariant lo <= hi.
+///
+/// NB: This is only to be used during migration and refactoring. Do *not* use this for new
+/// interned expressions.
+pub(crate) static DUMMY_SP: Span = Span { lo: 10001, hi: 1 };
+
+impl Span {
+    pub(crate) fn to(&self, other: Span) -> Span {
+        Self {
+            lo: self.lo,
+            hi: other.hi,
+        }
+    }
 }
 
 impl From<(usize, usize)> for Span {

--- a/libslide/src/grammar.rs
+++ b/libslide/src/grammar.rs
@@ -149,18 +149,6 @@ impl From<f64> for Expr {
     }
 }
 
-impl From<BinaryExpr<InternedExpr>> for InternedExpr {
-    fn from(binary_expr: BinaryExpr<InternedExpr>) -> Self {
-        intern_expr!(Expr::BinaryExpr(binary_expr))
-    }
-}
-
-impl From<UnaryExpr<InternedExpr>> for InternedExpr {
-    fn from(unary_expr: UnaryExpr<InternedExpr>) -> Self {
-        intern_expr!(Expr::UnaryExpr(unary_expr))
-    }
-}
-
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Hash, Debug)]
 pub enum BinaryOperator {
     // Discrimant values exist to describe a formal ordering, and are grouped by tens to express

--- a/libslide/src/grammar/intern.rs
+++ b/libslide/src/grammar/intern.rs
@@ -5,6 +5,7 @@
 
 use crate::emit::Emit;
 use crate::grammar::{Expr, ExprPat, Grammar};
+use crate::Span;
 
 use core::cmp::Ordering;
 use lasso::{Rodeo, Spur};
@@ -16,91 +17,163 @@ use std::sync::RwLock;
 /// Describes an interned slide expression.
 pub trait InternedExpression
 where
-    Self: Copy + Deref + Ord + From<super::BinaryExpr<Self>> + From<super::UnaryExpr<Self>>,
+    Self: Copy + Deref + Ord,
 {
+    /// The type of expression interned by Self.
     type Inner;
 
     /// Returns whether the expression is a statically-evaluatable constant.
     fn is_const(&self) -> bool;
 
     /// Paranthesizes `inner`.
-    fn paren(inner: Self) -> Self;
+    fn paren(inner: Self, span: Span) -> Self;
 
     /// Brackets `inner`.
-    fn bracket(inner: Self) -> Self;
+    fn bracket(inner: Self, span: Span) -> Self;
+
+    /// Creates an InternedExpression from a [BinaryExpr](super::BinaryExpr).
+    fn binary(expr: super::BinaryExpr<Self>, span: Span) -> Self;
+
+    /// Creates an InternedExpression from a [UnaryExpr](super::UnaryExpr).
+    fn unary(expr: super::UnaryExpr<Self>, span: Span) -> Self;
 
     /// Returns an empty expression.
-    fn empty() -> Self;
+    fn empty(span: Span) -> Self;
+
+    /// Returns the span of the expression.
+    fn span(&self) -> Span;
+}
+
+/// An interner for arbitrary, hashable, non-string types.
+#[derive(Debug)]
+struct Interner<T> {
+    /// Why two intern tables? The idea is to hash a grammar to a string, intern the string in a
+    /// [Rodeo](lasso::Rodeo), and keep a table mapping the interned string reference to the
+    /// original grammar. Rodeo provides fast lookups, so the largest constraint here is creating
+    /// the string hash from a grammar.
+    ///
+    /// Okay, but why not just a `Map<Grammar, Grammar>`? This doesn't quite work because then we
+    /// need to store &Grammar on the interned struct, which needs a lifetime. The only lifetime
+    /// that would work non-locally is `'static`, but that is longer than the lifetime of variables
+    /// declared via lazy_static.  
+    ///
+    /// Okay, but why not just a `Map<String, Grammar>`? Because then we must store a string on the
+    /// interned struct, and clone a string anytime we intern a value (even if it already exists).
+    /// This is much more expensive than a reference or 32-bit [Spur](lasso::Spur).
+    rodeo: Rodeo<Spur>,
+
+    /// Two structurally equivalent expressions may have different spurs, so we have to make sure
+    /// that the expression we dereference is the one corresponding to exactly that span. For
+    /// example, in
+    ///   1 + 2 * 3 and
+    ///   2 * 3 + 1
+    /// the interned value for `2 * 3` will have the same spur, but if we dereference them to the
+    /// same underlying expression, the spans of `2` and `3` will be the same when they are not.
+    ///
+    /// Thus, we hash by both spur and the span of the interned expression.
+    // TODO(ayazhafiz): this might not be enough. For example, if we start recording the location
+    // of operators, then this will fail for
+    //   1 +  3
+    //   1  + 3
+    // Plus, marking expressions as unique based of the span gets rid of most of the usefulness of
+    // interning anyway. Maybe this can just become an `Rc` container.
+    spur_map: HashMap<(Spur, Span), Box<T>>,
+}
+
+impl<T> Default for Interner<T> {
+    fn default() -> Self {
+        Self {
+            rodeo: Rodeo::default(),
+            spur_map: HashMap::new(),
+        }
+    }
 }
 
 macro_rules! make_interner {
-    ($($intern_macro:ident, $ty:ty, $interned_struct:ident, $rodeo:ident, $spur2expr:ident)*) => {$(
+    ($($intern_macro:ident, $ty:ty, $interned_struct:ident, $interner:ident)*) => {$(
         lazy_static! {
-            // Why two intern tables? The idea is to hash a grammar to a string, intern the string
-            // in Rodeo, and keep a table mapping the interned string reference to the original
-            // grammar. Rodeo provides fast lookups, so the largest constraint here is creating the
-            // string hash from a grammar.
-            //
-            // Okay, but why not just a Map<Grammar, Grammar>? This doesn't quite work because then
-            // we need to store &Grammar on the interned struct, which needs a lifetime. The only
-            // lifetime that would work non-locally is 'static, but that is longer than the
-            // lifetime of variables declared via lazy_static.
-            //
-            // Okay, but why not just a Map<String, Grammar>? Because then we must store a string
-            // on the interned struct, and clone a string anytime we intern a value (even if it
-            // already exists). This is much more expensive than a reference or 32-bit Spur.
-            static ref $rodeo: RwLock<Rodeo<Spur>> = RwLock::new(Rodeo::default());
-            static ref $spur2expr: RwLock<HashMap<Spur, $ty>> = RwLock::new(HashMap::new());
+            static ref $interner: RwLock<Interner<$ty>> = RwLock::new(Interner::default());
         }
 
         /// An interned version of an expression.
-        #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-        pub struct $interned_struct(pub(crate) Spur);
+        ///
+        /// NB: interned expressions are equivalent if they point to the same underlying expression,
+        /// even though two interned expressions may have different [span](crate::Span)s.
+        #[derive(Debug, Copy, Clone)]
+        pub struct $interned_struct {
+            /// Pointer to an expression in the intern map.
+            spur: Spur,
+            /// The original span of this expression from an input source code.
+            /// Even though the expression is interned, this span is distinct and serves as a
+            /// backwards-mapping to where the expression originally came from.
+            pub(crate) span: Span,
+        }
 
         impl $interned_struct {
             /// Interns the expression, or returns the existing interned reference if it already
             /// exists.
-            pub(crate) fn intern(expr: $ty) -> Self {
+            pub(crate) fn intern<Sp>(expr: $ty, span: Sp) -> Self
+            where
+                Sp: Into<Span>
+            {
+                let span = span.into();
                 let hash = expr.emit_s_expression();
-                let mb = $rodeo
-                    .read()
-                    .expect("Failed to read intern rodeo; likely poisoned.")
-                    .get(hash);
-                match mb {
-                    Some(spur) => Self(spur),
-                    None => {
-                        // NB: race condition:
-                        // Suppose we write an expression E to the rodeo (1),
-                        // but before we write the spur -> expression mapping (2),
-                        // another thread interns E.
-                        // In that case we would return a spur corresponding to E.
-                        // If the thread then tries to dereference the interned expression
-                        // before the spur -> E mapping is written, the thread would blow up.
-                        // To avoid this, lock the rodeo until we write both to both the rodeo and
-                        // the spur mapping.
-                        // TODO(ayazhafiz): containerize?
-                        let mut spur_write_lk = $rodeo.write().expect("Failed to write to intern rodeo; likely poisoned.");
-                        let spur = spur_write_lk.get_or_intern(expr.emit_s_expression()); // (1)
-                        $spur2expr
-                            .write()
-                            .expect("Failed to write to intern reverse map; likely poisoned.")
-                            .insert(spur, expr); // (2)
-                        Self(spur)
+                let mb = {
+                    let interner_lk = $interner.read().expect("Failed to read interner; likely poisoned.");
+                    interner_lk.rodeo.get(hash)
+                };
+                let spur = match mb {
+                    Some(spur) => {
+                        let expr_with_span_exists = {
+                            let interner_lk = $interner.read().expect("Failed to read interner; likely poisoned.");
+                            interner_lk.spur_map.get(&(spur, span)).is_some()
+                        };
+                        if !expr_with_span_exists {
+                            // No need to acquire an RAII lock here because after insertion, the
+                            // interner is in a well-formed state. Reads before the write will lead
+                            // to a subsequent write (OK), and reads after the write will be as
+                            // expected.
+                            let mut interner_lk = $interner.write().expect("Failed to read intern reverse map; likely poisoned.");
+                            interner_lk.spur_map.insert((spur, span), Box::new(expr));
+                        }
+                        spur
                     }
-                }
+                    None => {
+                        let hash = expr.emit_s_expression();
+                        // Lock up the interner to prevent a race condition.
+                        let mut interner_lk = $interner.write().expect("Failed to get rodeo");
+                        let spur = interner_lk.rodeo.get_or_intern(hash);
+                        interner_lk.spur_map.insert((spur, span), Box::new(expr));
+                        spur
+                    }
+                };
+                Self {spur, span}
             }
         }
 
         /// Interns an expression.
-        #[doc(hidden)]
         #[macro_export]
         macro_rules! $intern_macro {
-            ($expr: expr) => {
-                $interned_struct::intern($expr)
+            ($expr: expr, $span: expr) => {
+                $interned_struct::intern($expr, $span)
             }
         }
 
         impl Grammar for $interned_struct {}
+
+        impl core::hash::Hash for $interned_struct {
+            fn hash<H: core::hash::Hasher>(&self, state: &mut H) {
+                self.spur.hash(state);
+            }
+        }
+
+        impl PartialEq for $interned_struct {
+            fn eq(&self, other: &Self) -> bool {
+                self.spur.eq(&other.spur)
+            }
+        }
+
+        impl Eq for $interned_struct {}
 
         impl Emit for $interned_struct {
             fn emit_pretty(&self) -> String {
@@ -131,15 +204,62 @@ macro_rules! make_interner {
         impl Deref for $interned_struct {
             type Target = <Self as InternedExpression>::Inner;
 
-            fn deref(&self) -> &<Self as InternedExpression>::Inner {
-                let table = $spur2expr.read().expect("Failed to read intern reverse map; likely poisoned.");
-                let val = table.get(&self.0).expect("BUG: intern key does not map to an interned value");
+            fn deref(&self) -> &Self::Target {
+                let interner_lk = $interner.read().expect("Failed to read interner; likely poisoned.");
+                let interned_p = interner_lk.spur_map.get(&(self.spur, self.span)).unwrap_or_else(|| panic!(
+                    // Constructing this formatted string is decently expensive, so avoid it unless
+                    // we actually can't find the interned value.
+                    "BUG: intern key does not map to an interned value.
+                    Self: {:?}
+                    Rodeo: {:?}
+                    Spur Map: {:?}", self, interner_lk.rodeo, interner_lk.spur_map
+                ));
+                let inner: &Self::Target = &**interned_p;
                 // Safety:
+                //
                 // - semantics: OK because cast to ptr, then deref ptr and return reference
+                //
                 // - lifetimes: OK because values present in the intern tables last for the lifetime
-                //   of the table, which is static.
+                //   of the table, which is (nearly) static.
+                //
+                //   Note that the reference to the boxed expression does not truly have a static
+                //   lifetime (and hence the need for an unsafe cast). This is because `lazy_static`
+                //   is not actually `'static`; however, once interned, an expression persists for
+                //   the remaining lifetime of the program, so its lifetime is "relatively static"
+                //   (at least as long as that of any of its users).
+                //
+                // - invalidation of reference: OK because the reference to the expression we return
+                //   is never reallocated. We may worry that if we return a reference to an
+                //   expression that is a value of a k-v pair in a hashmap, if the hashmap is
+                //   reallocated while we are using the reference, whatever we read is junk.
+                //
+                //   However, the reference to the expression returned is a boxed expression pointed
+                //   to from the value of the k-v pair, and so will never be reallocated.  As an
+                //   illustration, the k-v pairs can be seen as
+                //
+                //   (spur, span) -> expr pointer -> Box<Expr>
+                //   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^              -- k-v pair belonging to a hash map,
+                //                                                may be reallocated (e.g. if the
+                //                                                map is resized)
+                //                                   ^^^^^^^^^ -- "static" address in memory
+                //
+                //   And the reallocation model can be seen as
+                //
+                //   ------ Hash map -----
+                //   |   |   |   | k |   |     (before reallocation)
+                //   |   |   |   | v |   |
+                //   --------------|------
+                //                 \
+                //          /-------\-> expr -- return a reference to this
+                //         /
+                //   ------|--------------
+                //   |   | v |   |   |   |
+                //   |   | k |   |   |   |     (after reallocation)
+                //   ------ Hash map -----
+                //
+                //   so even if the map is reallocated, our reference is valid.
                 unsafe {
-                    &*(val as *const $ty)
+                    &*(inner as *const $ty)
                 }
             }
         }
@@ -155,18 +275,12 @@ macro_rules! make_interner {
                 self.as_ref().cmp(&other.as_ref())
             }
         }
-
-        impl From<$ty> for $interned_struct {
-            fn from(expr: $ty) -> Self {
-                $intern_macro!(expr)
-            }
-        }
     )*};
 }
 
 make_interner! {
-    intern_expr, Expr, InternedExpr, EXPR_RODEO, SPUR2EXPR
-    intern_expr_pat, ExprPat, InternedExprPat, EXPR_PAT_RODEO, SPUR2EXPR_PAT
+    intern_expr, Expr, InternedExpr, EXPR_RODEO
+    intern_expr_pat, ExprPat, InternedExprPat, EXPR_PAT_RODEO
 }
 
 impl InternedExpression for InternedExpr {
@@ -178,19 +292,34 @@ impl InternedExpression for InternedExpr {
     }
 
     #[inline]
-    fn paren(inner: InternedExpr) -> Self {
-        intern_expr!(Expr::Parend(inner))
+    fn paren(inner: InternedExpr, span: Span) -> Self {
+        intern_expr!(Expr::Parend(inner), span)
     }
 
     #[inline]
-    fn bracket(inner: InternedExpr) -> Self {
-        intern_expr!(Expr::Bracketed(inner))
+    fn bracket(inner: InternedExpr, span: Span) -> Self {
+        intern_expr!(Expr::Bracketed(inner), span)
     }
 
     #[inline]
-    fn empty() -> Self {
+    fn binary(expr: super::BinaryExpr<Self>, span: Span) -> Self {
+        intern_expr!(Expr::BinaryExpr(expr), span)
+    }
+
+    #[inline]
+    fn unary(expr: super::UnaryExpr<Self>, span: Span) -> Self {
+        intern_expr!(Expr::UnaryExpr(expr), span)
+    }
+
+    #[inline]
+    fn empty(span: Span) -> Self {
         // Variables must be named, so we can encode an unnamed variable as an empty expression.
-        intern_expr!(Expr::Var(String::new()))
+        intern_expr!(Expr::Var(String::new()), span)
+    }
+
+    #[inline]
+    fn span(&self) -> Span {
+        self.span
     }
 }
 
@@ -203,18 +332,33 @@ impl InternedExpression for InternedExprPat {
     }
 
     #[inline]
-    fn paren(inner: InternedExprPat) -> Self {
-        intern_expr_pat!(ExprPat::Parend(inner))
+    fn paren(inner: InternedExprPat, span: Span) -> Self {
+        intern_expr_pat!(ExprPat::Parend(inner), span)
     }
 
     #[inline]
-    fn bracket(inner: InternedExprPat) -> Self {
-        intern_expr_pat!(ExprPat::Bracketed(inner))
+    fn bracket(inner: InternedExprPat, span: Span) -> Self {
+        intern_expr_pat!(ExprPat::Bracketed(inner), span)
     }
 
     #[inline]
-    fn empty() -> Self {
+    fn binary(expr: super::BinaryExpr<Self>, span: Span) -> Self {
+        intern_expr_pat!(ExprPat::BinaryExpr(expr), span)
+    }
+
+    #[inline]
+    fn unary(expr: super::UnaryExpr<Self>, span: Span) -> Self {
+        intern_expr_pat!(ExprPat::UnaryExpr(expr), span)
+    }
+
+    #[inline]
+    fn empty(span: Span) -> Self {
         // Patterns must be named, so we can encode an unnamed pattern as an empty expression.
-        intern_expr_pat!(ExprPat::VarPat(String::new()))
+        intern_expr_pat!(ExprPat::VarPat(String::new()), span)
+    }
+
+    #[inline]
+    fn span(&self) -> Span {
+        self.span
     }
 }

--- a/libslide/src/grammar/pattern.rs
+++ b/libslide/src/grammar/pattern.rs
@@ -57,18 +57,6 @@ impl core::hash::Hash for ExprPat {
     }
 }
 
-impl From<BinaryExpr<InternedExprPat>> for InternedExprPat {
-    fn from(binary_expr: BinaryExpr<InternedExprPat>) -> Self {
-        intern_expr_pat!(ExprPat::BinaryExpr(binary_expr))
-    }
-}
-
-impl From<UnaryExpr<InternedExprPat>> for InternedExprPat {
-    fn from(unary_expr: UnaryExpr<InternedExprPat>) -> Self {
-        intern_expr_pat!(ExprPat::UnaryExpr(unary_expr))
-    }
-}
-
 impl PartialOrd for ExprPat {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         Some(self.cmp(other))

--- a/libslide/src/math/poly.rs
+++ b/libslide/src/math/poly.rs
@@ -412,23 +412,41 @@ impl Poly {
                     continue;
                 }
                 1 => relative_to,
-                _ => intern_expr!(Expr::BinaryExpr(BinaryExpr::mult(
-                    Expr::Const(*coeff as f64),
-                    relative_to,
-                ))),
+                _ => intern_expr!(
+                    Expr::BinaryExpr(BinaryExpr::mult(
+                        intern_expr!(
+                            Expr::Const(*coeff as f64),
+                            /* TODO:propagate span */ crate::DUMMY_SP
+                        ),
+                        relative_to
+                    )),
+                    /* TODO: propagate span */ crate::DUMMY_SP
+                ),
             };
 
             terms.push(match pow {
-                0 => intern_expr!(Expr::Const(*coeff as f64)),
+                0 => intern_expr!(
+                    Expr::Const(*coeff as f64),
+                    /* TODO: propagate span */ crate::DUMMY_SP
+                ),
                 1 => term,
-                _ => intern_expr!(Expr::BinaryExpr(BinaryExpr::exp(
-                    term,
-                    intern_expr!(Expr::Const(pow as f64)),
-                ))),
+                _ => intern_expr!(
+                    Expr::BinaryExpr(BinaryExpr::exp(
+                        term,
+                        intern_expr!(
+                            Expr::Const(pow as f64),
+                            /* TODO: propagate span */ crate::DUMMY_SP
+                        ),
+                    )),
+                    /* TODO: propagate span */ crate::DUMMY_SP
+                ),
             });
         }
         if terms.is_empty() {
-            return intern_expr!(Expr::Const(0.));
+            return intern_expr!(
+                Expr::Const(0.),
+                /* TODO: propagate span */ crate::DUMMY_SP
+            );
         }
 
         unflatten_binary_expr(
@@ -562,7 +580,7 @@ mod test {
                 let expr = parse_expr!($expr);
                 let relative: Option<&str> = $relative;
                 let has_relative = relative.is_some();
-                let rel = relative.map(|r: &str| parse_expr!(r)).unwrap_or(InternedExpr::empty());
+                let rel = relative.map(|r: &str| parse_expr!(r)).unwrap_or(InternedExpr::empty(crate::DUMMY_SP));
                 let rel_opt = if has_relative { Some(rel) } else { None };
                 let poly = Poly::from_expr(expr, rel_opt).ok().map(|(p, t)| (p, t.map(|expr| expr.to_string())));
                 assert_eq!(poly, $expected);

--- a/libslide/src/parser/expression_parser.rs
+++ b/libslide/src/parser/expression_parser.rs
@@ -38,7 +38,7 @@ impl ExpressionParser {
                 cut_name = name.substring(1, name.len() - 1)
             )),
         );
-        intern_expr!(Expr::Var(name))
+        intern_expr!(Expr::Var(name), span)
     }
 }
 
@@ -77,12 +77,12 @@ impl Parser<Stmt> for ExpressionParser {
         parsed
     }
 
-    fn parse_float(&mut self, f: f64, _span: Span) -> Self::Expr {
-        intern_expr!(Expr::Const(f))
+    fn parse_float(&mut self, f: f64, span: Span) -> Self::Expr {
+        intern_expr!(Expr::Const(f), span)
     }
 
-    fn parse_variable(&mut self, name: String, _span: Span) -> Self::Expr {
-        intern_expr!(Expr::Var(name))
+    fn parse_variable(&mut self, name: String, span: Span) -> Self::Expr {
+        intern_expr!(Expr::Var(name), span)
     }
 
     fn parse_var_pattern(&mut self, name: String, span: Span) -> Self::Expr {
@@ -101,7 +101,7 @@ impl Parser<Stmt> for ExpressionParser {
 #[cfg(test)]
 mod tests {
     parser_tests! {
-        parse_expression
+        expr
 
         variable:                "a"
         variable_in_op_left:     "a + 1"

--- a/libslide/src/parser/expression_pattern_parser.rs
+++ b/libslide/src/parser/expression_pattern_parser.rs
@@ -43,8 +43,8 @@ impl Parser<InternedExprPat> for ExpressionPatternParser {
         parsed
     }
 
-    fn parse_float(&mut self, f: f64, _span: Span) -> Self::Expr {
-        intern_expr_pat!(ExprPat::Const(f))
+    fn parse_float(&mut self, f: f64, span: Span) -> Self::Expr {
+        intern_expr_pat!(ExprPat::Const(f), span)
     }
 
     fn parse_variable(&mut self, name: String, span: Span) -> Self::Expr {
@@ -59,58 +59,29 @@ impl Parser<InternedExprPat> for ExpressionPatternParser {
                 name = name,
             )),
         );
-        intern_expr_pat!(ExprPat::VarPat(name))
+        intern_expr_pat!(ExprPat::VarPat(name), span)
     }
 
-    fn parse_var_pattern(&mut self, name: String, _span: Span) -> Self::Expr {
-        intern_expr_pat!(ExprPat::VarPat(name))
+    fn parse_var_pattern(&mut self, name: String, span: Span) -> Self::Expr {
+        intern_expr_pat!(ExprPat::VarPat(name), span)
     }
 
-    fn parse_const_pattern(&mut self, name: String, _span: Span) -> Self::Expr {
-        intern_expr_pat!(ExprPat::ConstPat(name))
+    fn parse_const_pattern(&mut self, name: String, span: Span) -> Self::Expr {
+        intern_expr_pat!(ExprPat::ConstPat(name), span)
     }
 
-    fn parse_any_pattern(&mut self, name: String, _span: Span) -> Self::Expr {
-        intern_expr_pat!(ExprPat::AnyPat(name))
+    fn parse_any_pattern(&mut self, name: String, span: Span) -> Self::Expr {
+        intern_expr_pat!(ExprPat::AnyPat(name), span)
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use crate::scan;
-
     parser_tests! {
-        parse_expression_pattern
+        expr_pat
 
         pattern:                 "$a"
         pattern_in_op_left:      "$a + 1"
         pattern_in_op_right:     "1 + $a"
-    }
-
-    #[test]
-    fn common_subexpression_elimination() {
-        let program = "$v * #c + $v * #c";
-        let tokens = scan(program).tokens;
-        let (parsed, _) = parse(tokens);
-        let (l, r) = match (*parsed).clone() {
-            ExprPat::BinaryExpr(BinaryExpr { lhs, rhs, .. }) => (lhs, rhs),
-            _ => unreachable!(),
-        };
-        assert!(std::ptr::eq(l.as_ref(), r.as_ref())); // $v * #c
-
-        let (ll, lr, rl, rr) = match (l.as_ref(), r.as_ref()) {
-            (
-                ExprPat::BinaryExpr(BinaryExpr {
-                    lhs: ll, rhs: lr, ..
-                }),
-                ExprPat::BinaryExpr(BinaryExpr {
-                    lhs: rl, rhs: rr, ..
-                }),
-            ) => (ll, lr, rl, rr),
-            _ => unreachable!(),
-        };
-        assert!(std::ptr::eq(ll.as_ref(), rl.as_ref())); // 1
-        assert!(std::ptr::eq(lr.as_ref(), rr.as_ref())); // 2
     }
 }

--- a/libslide/src/parser/test_utils.rs
+++ b/libslide/src/parser/test_utils.rs
@@ -1,6 +1,10 @@
-#![allow(unused_macros)]
+#![cfg(test)]
+
 macro_rules! __parse {
-    ($parser:ident, $inout:expr) => {
+    ($parser:ident, $inout:expr) => {{
+        use crate::parser::$parser;
+        use crate::scanner::scan;
+
         let inout: Vec<&str> = $inout.split(" => ").collect();
         let pin = inout[0];
         let pout = if inout.len() > 1 {
@@ -10,7 +14,40 @@ macro_rules! __parse {
         };
         let tokens = scan(pin).tokens;
         let (parsed, _) = $parser(tokens);
-        assert_eq!(parsed.to_string(), pout);
+        (parsed, pin, pout)
+    }};
+}
+
+macro_rules! __check_parsed {
+    (expr: $inout:expr) => {
+        use crate::grammar::*;
+        use crate::parser::test_utils::verify_expr_spans;
+
+        let (parsed, input, expected_out) = __parse!(parse_expression, $inout);
+        assert_eq!(parsed.to_string(), expected_out);
+
+        if input == expected_out {
+            // We can automate verification of spans only if the input is in the same emit form as
+            // the output.
+            let inner_expr = match parsed {
+                Stmt::Expr(inner) => inner,
+                Stmt::Assignment(Assignment { rhs, .. }) => rhs,
+            };
+            verify_expr_spans(&inner_expr, &input);
+        }
+    };
+
+    (expr_pat: $inout:expr) => {
+        use crate::parser::test_utils::verify_expr_pat_spans;
+
+        let (parsed, input, expected_out) = __parse!(parse_expression_pattern, $inout);
+        assert_eq!(parsed.to_string(), expected_out);
+
+        if input == expected_out {
+            // We can automate verification of spans only if the input is in the same emit form as
+            // the output.
+            verify_expr_pat_spans(&parsed, &input);
+        }
     };
 }
 
@@ -19,42 +56,58 @@ macro_rules! common_parser_tests {
     $(
         #[test]
         fn $name() {
-            use crate::scanner::{scan};
-            use crate::parser::{parse_expression, parse_expression_pattern};
-
-            __parse!(parse_expression, $inout);
-            __parse!(parse_expression_pattern, $inout);
+            __check_parsed!(expr: $inout);
+            __check_parsed!(expr_pat: $inout);
         }
     )*
     }
 }
 
 macro_rules! parser_tests {
-    ($parser:ident $($name:ident: $program:expr)*) => {
+    ($kind:ident $($name:ident: $program:expr)*) => {
     $(
         #[test]
         fn $name() {
-            use crate::scanner::{scan};
-            use crate::parser::{$parser};
-
-            __parse!($parser, $program);
+            __check_parsed!($kind: $program);
         }
     )*
     }
 }
 
-macro_rules! parser_error_tests {
-    ($parser:ident $($name:ident: $program:expr => $error:expr)*) => {
-    $(
-        #[test]
-        fn $name() {
-            use crate::scanner::{scan};
-            use crate::parser::{$parser};
+use crate::grammar::*;
+use crate::Span;
 
-            let tokens = scan($program).tokens;
-            let (_, errors) = $parser(tokens);
-            assert_eq!(errors.join("\n"), $error);
+fn check_span(span: Span, input: &str, actual: String) {
+    let expected_from_span = &input[span.lo..span.hi];
+    assert_eq!(expected_from_span, actual, "Spans mismatch!");
+}
+
+pub fn verify_expr_spans(expr: &InternedExpr, input: &str) {
+    check_span(expr.span, input, expr.to_string());
+    match expr.as_ref() {
+        Expr::BinaryExpr(BinaryExpr { lhs, rhs, .. }) => {
+            verify_expr_spans(lhs, input);
+            verify_expr_spans(rhs, input);
         }
-    )*
+        Expr::UnaryExpr(UnaryExpr { rhs, .. }) => {
+            verify_expr_spans(rhs, input);
+        }
+        Expr::Parend(inner) | Expr::Bracketed(inner) => verify_expr_spans(inner, input),
+        _ => (),
+    }
+}
+
+pub fn verify_expr_pat_spans(expr: &InternedExprPat, input: &str) {
+    check_span(expr.span, input, expr.to_string());
+    match expr.as_ref() {
+        ExprPat::BinaryExpr(BinaryExpr { lhs, rhs, .. }) => {
+            verify_expr_pat_spans(lhs, input);
+            verify_expr_pat_spans(rhs, input);
+        }
+        ExprPat::UnaryExpr(UnaryExpr { rhs, .. }) => {
+            verify_expr_pat_spans(rhs, input);
+        }
+        ExprPat::Parend(inner) | ExprPat::Bracketed(inner) => verify_expr_pat_spans(inner, input),
+        _ => (),
     }
 }

--- a/slide/src/test/ui/emit/debug.slide
+++ b/slide/src/test/ui/emit/debug.slide
@@ -9,11 +9,15 @@
 
 ~~~stdout
 Expr(
-    InternedExpr(
-        Spur {
+    InternedExpr {
+        spur: Spur {
             key: 7,
         },
-    ),
+        span: Span {
+            lo: 0,
+            hi: 14,
+        },
+    },
 )
 ~~~stdout
 


### PR DESCRIPTION
This prepares for a "linter" pass that will walk a parse tree and detect
"bad" patterns, like `++++5` which is trivially reducible to `5`.

Future work may also use these spans to provide intellegent suggestions
on reducibility, for example noting that `3 + 4` is the span that was
converted to `7` in an expression like `2 * 3 / (3 + 4)`.

Also, this change has nearly convinced me that having the interner in a
state as we do now is a useless and bad idea, since it's (1) already
pretty complicated and (2) making expressions unique by their span
defeats the usefulness of caching structurally identical expressions.

Part of #135