### PR TITLE
Introduce support for lints

### DIFF
--- a/libslide/src/common.rs
+++ b/libslide/src/common.rs
@@ -1,5 +1,7 @@
 //! Common types used by libslide.
 
+use std::cmp::Ordering;
+
 /// Describes the character span of a substring in a text.
 ///
 /// For example, in "abcdef", "bcd" has the span (1, 4).
@@ -25,6 +27,28 @@ impl Span {
         Self {
             lo: self.lo,
             hi: other.hi,
+        }
+    }
+}
+
+impl PartialOrd for Span {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for Span {
+    fn cmp(&self, other: &Self) -> Ordering {
+        if self.lo < other.lo {
+            Ordering::Less
+        } else if self.lo > other.lo {
+            Ordering::Greater
+        } else if self.hi < other.hi {
+            Ordering::Less
+        } else if self.hi > other.hi {
+            Ordering::Greater
+        } else {
+            Ordering::Equal
         }
     }
 }

--- a/libslide/src/grammar.rs
+++ b/libslide/src/grammar.rs
@@ -4,9 +4,11 @@
 mod intern;
 mod pattern;
 mod transformer;
+mod visitor;
 pub use intern::*;
 pub use pattern::*;
 pub use transformer::*;
+pub use visitor::*;
 
 use crate::emit::Emit;
 use crate::scanner::types::{Token, TokenType};
@@ -21,9 +23,25 @@ where
 {
 }
 
+/// A statement in a slide program.
 #[derive(Clone, Debug)]
 pub enum Stmt {
+    /// An expression statement is a statement that consists solely of an expression. For example,
+    /// the slide program
+    ///
+    /// ```text
+    /// 1 + 1
+    /// ```
+    ///
+    /// contains one statement, that statement also being an expression.
     Expr(InternedExpr),
+    /// An assignment binds some value to a variable. For example the statement
+    ///
+    /// ```text
+    /// x = 1 + 1
+    /// ```
+    ///
+    /// binds the expression "1 + 1" to "x".
     Assignment(Assignment),
 }
 

--- a/libslide/src/grammar/pattern.rs
+++ b/libslide/src/grammar/pattern.rs
@@ -1,7 +1,9 @@
 use super::*;
 
+/// A slide expression pattern.
 #[derive(Clone, Debug)]
 pub enum ExprPat {
+    /// A constant
     Const(f64),
     /// Pattern matching a variable
     VarPat(String),
@@ -9,9 +11,13 @@ pub enum ExprPat {
     ConstPat(String),
     /// Pattern matching any expression
     AnyPat(String),
+    /// A binary expression
     BinaryExpr(BinaryExpr<InternedExprPat>),
+    /// A unary expression
     UnaryExpr(UnaryExpr<InternedExprPat>),
+    /// A paranthesized expression
     Parend(InternedExprPat),
+    /// A bracketed expression
     Bracketed(InternedExprPat),
 }
 

--- a/libslide/src/grammar/visitor.rs
+++ b/libslide/src/grammar/visitor.rs
@@ -1,0 +1,104 @@
+//! Traits for visiting slide grammar trees.
+
+use super::*;
+use crate::Span;
+
+/// Describes a [statement][super::Stmt] visitor.
+pub trait StmtVisitor<'a> {
+    fn visit(&mut self, stmt: &'a Stmt) {
+        match stmt {
+            Stmt::Expr(expr) => self.visit_expr(expr),
+            Stmt::Assignment(asgn) => self.visit_asgn(asgn),
+        }
+    }
+
+    fn visit_asgn(&mut self, asgn: &'a Assignment) {
+        self.visit_var(&asgn.var);
+        self.visit_expr(&asgn.rhs);
+    }
+
+    fn visit_expr(&mut self, expr: &'a InternedExpr) {
+        match expr.as_ref() {
+            Expr::Const(k) => self.visit_const(k),
+            Expr::Var(v) => self.visit_var(v),
+            Expr::BinaryExpr(b) => self.visit_binary(b),
+            Expr::UnaryExpr(u) => self.visit_unary(u, expr.span),
+            Expr::Parend(p) => self.visit_parend(p, expr.span),
+            Expr::Bracketed(b) => self.visit_bracketed(b, expr.span),
+        }
+    }
+
+    fn visit_const(&mut self, _konst: &'a f64) {}
+
+    fn visit_var(&mut self, _var: &'a str) {}
+
+    fn visit_binary_op(&mut self, _op: BinaryOperator) {}
+
+    fn visit_binary(&mut self, expr: &'a BinaryExpr<InternedExpr>) {
+        self.visit_expr(&expr.lhs);
+        self.visit_binary_op(expr.op);
+        self.visit_expr(&expr.rhs);
+    }
+
+    fn visit_unary_op(&mut self, _op: UnaryOperator) {}
+
+    fn visit_unary(&mut self, expr: &'a UnaryExpr<InternedExpr>, _span: Span) {
+        self.visit_unary_op(expr.op);
+        self.visit_expr(&expr.rhs);
+    }
+
+    fn visit_parend(&mut self, expr: &'a InternedExpr, _span: Span) {
+        self.visit_expr(expr);
+    }
+
+    fn visit_bracketed(&mut self, expr: &'a InternedExpr, _span: Span) {
+        self.visit_expr(expr);
+    }
+}
+
+/// Describes an [expression pattern][super::ExprPat] visitor.
+pub trait ExprPatVisitor<'a> {
+    fn visit(&mut self, expr_pat: &'a InternedExprPat) {
+        match expr_pat.as_ref() {
+            ExprPat::Const(k) => self.visit_const(k),
+            ExprPat::VarPat(v) => self.visit_var_pat(v, expr_pat.span),
+            ExprPat::ConstPat(k) => self.visit_const_pat(k, expr_pat.span),
+            ExprPat::AnyPat(a) => self.visit_any_pat(a, expr_pat.span),
+            ExprPat::BinaryExpr(b) => self.visit_binary(b),
+            ExprPat::UnaryExpr(u) => self.visit_unary(u, expr_pat.span),
+            ExprPat::Parend(p) => self.visit_parend(p, expr_pat.span),
+            ExprPat::Bracketed(b) => self.visit_bracketed(b, expr_pat.span),
+        }
+    }
+
+    fn visit_const(&mut self, _konst: &f64) {}
+
+    fn visit_var_pat(&mut self, _var_pat: &'a str, _span: Span) {}
+
+    fn visit_const_pat(&mut self, _const_pat: &'a str, _span: Span) {}
+
+    fn visit_any_pat(&mut self, _any_pat: &'a str, _span: Span) {}
+
+    fn visit_binary_op(&mut self, _op: BinaryOperator) {}
+
+    fn visit_binary(&mut self, expr: &'a BinaryExpr<InternedExprPat>) {
+        self.visit(&expr.lhs);
+        self.visit_binary_op(expr.op);
+        self.visit(&expr.rhs);
+    }
+
+    fn visit_unary_op(&mut self, _op: UnaryOperator) {}
+
+    fn visit_unary(&mut self, expr: &'a UnaryExpr<InternedExprPat>, _span: Span) {
+        self.visit_unary_op(expr.op);
+        self.visit(&expr.rhs);
+    }
+
+    fn visit_parend(&mut self, expr: &'a InternedExprPat, _span: Span) {
+        self.visit(expr);
+    }
+
+    fn visit_bracketed(&mut self, expr: &'a InternedExprPat, _span: Span) {
+        self.visit(expr);
+    }
+}

--- a/libslide/src/lib.rs
+++ b/libslide/src/lib.rs
@@ -202,7 +202,7 @@
 
 #[macro_use]
 mod grammar;
-pub use grammar::Grammar;
+pub use grammar::{ExprPat, Grammar, Stmt};
 
 mod common;
 pub use common::*;
@@ -211,10 +211,16 @@ pub mod diagnostics;
 
 pub mod scanner;
 pub use scanner::scan;
+pub use scanner::Token;
 
 mod parser;
 pub use parser::parse_expression;
 pub use parser::parse_expression_pattern;
+
+mod linter;
+pub use linter::lint_expr_pat;
+pub use linter::lint_stmt;
+pub use linter::LintConfig;
 
 mod partial_evaluator;
 pub use partial_evaluator::evaluate;

--- a/libslide/src/linter.rs
+++ b/libslide/src/linter.rs
@@ -1,0 +1,121 @@
+//! Provides linter-like diagnostics for a slide program.
+
+macro_rules! explain_lint {
+    ($(#[doc = $doc:expr])+ $code:ident: $linter:ident) => {
+        use crate::linter::LintExplanation;
+
+        $(#[doc = $doc])+
+        impl<'a> LintExplanation for $linter<'a> {
+            const CODE: &'static str = stringify!($code);
+            const EXPLANATION: &'static str = concat!($($doc, "\n"),+);
+        }
+    };
+}
+
+mod stmt;
+use stmt::*;
+
+mod expr_pat;
+use expr_pat::*;
+
+use crate::diagnostics::Diagnostic;
+use crate::grammar::{Grammar, InternedExprPat, Stmt};
+
+use std::collections::HashMap;
+
+/// Describes a slide program linter. A `Linter` is implemented on a slide [Grammar].
+///
+/// [Grammar]: [crate::grammar::Grammar].
+pub trait LintRule<'a, G>
+where
+    Self: LintExplanation,
+    G: Grammar,
+{
+    /// Lints a grammar given the original source code of the program.
+    fn lint(grammar: &G, source: &'a str) -> Vec<Diagnostic>;
+}
+
+pub trait LintExplanation {
+    const CODE: &'static str;
+    const EXPLANATION: &'static str;
+}
+
+/// Describes the configuration to use when linting a slide grammar.
+pub struct LintConfig {
+    stmt_linters: Vec<StmtLintRule>,
+    expr_pat_linters: Vec<ExprPatLintRule>,
+}
+
+impl Default for LintConfig {
+    fn default() -> Self {
+        Self {
+            stmt_linters: vec![
+                StmtLintRule::UnarySeriesLinter,
+                StmtLintRule::RedundantNestingLinter,
+            ],
+            expr_pat_linters: vec![ExprPatLintRule::SimilarNamesLinter],
+        }
+    }
+}
+
+impl LintConfig {
+    /// All lint codes and their explanations.
+    pub fn all_codes_with_explanations() -> HashMap<&'static str, &'static str> {
+        let mut map = HashMap::new();
+        map.extend(StmtLintRule::all_explanations());
+        map.extend(ExprPatLintRule::all_explanations());
+        map
+    }
+}
+
+/// Lints a slide [statement](crate::grammar::Stmt).
+pub fn lint_stmt(stmt: &Stmt, source: &str) -> Vec<Diagnostic> {
+    let config = LintConfig::default();
+    let mut diags = vec![];
+    for linter in config.stmt_linters {
+        diags.extend(linter.lint(stmt, source))
+    }
+    diags
+}
+
+/// Lints a slide [expression pattern](crate::grammar::ExprPat).
+pub fn lint_expr_pat(expr_pat: &InternedExprPat, source: &str) -> Vec<Diagnostic> {
+    let config = LintConfig::default();
+    let mut diags = vec![];
+    for linter in config.expr_pat_linters {
+        diags.extend(linter.lint(expr_pat, source))
+    }
+    diags
+}
+
+#[cfg(test)]
+mod test {
+    use super::LintConfig;
+
+    /// Each code must be of form Ldddd, where d is a digit.
+    #[test]
+    fn code_format() {
+        let lint_codes = LintConfig::all_codes_with_explanations();
+
+        for code in lint_codes.keys() {
+            assert_eq!(code.len(), 5);
+            assert!(code.starts_with('L'));
+            for ch in code.chars().skip(1) {
+                assert!(matches!(ch, '0'..='9'));
+            }
+        }
+    }
+
+    #[test]
+    fn no_conflicting_codes() {
+        let LintConfig {
+            stmt_linters,
+            expr_pat_linters,
+        } = LintConfig::default();
+
+        let num_lints = stmt_linters.len() + expr_pat_linters.len();
+        let num_lint_codes = LintConfig::all_codes_with_explanations().keys().count();
+
+        assert_eq!(num_lints, num_lint_codes);
+    }
+}

--- a/libslide/src/linter/expr_pat.rs
+++ b/libslide/src/linter/expr_pat.rs
@@ -1,0 +1,37 @@
+//! Lints for an expression pattern in a slide program.
+
+mod similar_names;
+use similar_names::*;
+
+use super::{LintExplanation, LintRule};
+use crate::diagnostics::Diagnostic;
+use crate::grammar::InternedExprPat;
+
+use std::collections::HashMap;
+
+macro_rules! define_expr_pat_lints {
+    ($($linter:ident,)*) => {
+        /// A lint rule applying to a statement in a slide program.
+        pub enum ExprPatLintRule {
+            $($linter),*
+        }
+
+        impl ExprPatLintRule {
+            pub fn lint(&self, expr_pat: &InternedExprPat, source: &str) -> Vec<Diagnostic> {
+                match self {
+                    $(Self::$linter => $linter::lint(expr_pat, source)),*
+                }
+            }
+
+            pub fn all_explanations() -> HashMap<&'static str, &'static str> {
+                let mut map = HashMap::new();
+                $(map.insert($linter::CODE, $linter::EXPLANATION);)*
+                map
+            }
+        }
+    };
+}
+
+define_expr_pat_lints! {
+    SimilarNamesLinter,
+}

--- a/libslide/src/linter/expr_pat/similar_names.rs
+++ b/libslide/src/linter/expr_pat/similar_names.rs
@@ -1,0 +1,164 @@
+explain_lint! {
+    ///The similar names lint detects expression patterns with very similar names.
+    ///
+    ///For example, the following pattern expression has different patterns with the same suffix "a":
+    ///
+    ///```text
+    ///$a + #a + _a + $a
+    ///```
+    ///
+    ///While this is expression is semantically valid, it can be difficuly to read and misleading,
+    ///since "a" is used in three separate and independent patterns. A clearer expression would be
+    ///
+    ///```text
+    ///$a + #b + _c + $a
+    ///```
+    L0003: SimilarNamesLinter
+}
+
+use crate::common::Span;
+use crate::diagnostics::Diagnostic;
+use crate::grammar::*;
+use crate::linter::LintRule;
+
+use std::collections::{BTreeMap, BTreeSet};
+
+#[derive(Eq, PartialEq, Ord, PartialOrd, Debug)]
+enum NameKind {
+    Var,
+    Const,
+    Any,
+}
+
+impl std::fmt::Display for NameKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            NameKind::Var => "var",
+            NameKind::Const => "const",
+            NameKind::Any => "any",
+        })
+    }
+}
+
+#[derive(Default, Debug)]
+struct NameCollection {
+    var_pat: Vec<Span>,
+    const_pat: Vec<Span>,
+    any_pat: Vec<Span>,
+}
+
+impl NameCollection {
+    fn used_patterns(&self) -> BTreeSet<NameKind> {
+        let mut used = BTreeSet::new();
+        if !self.var_pat.is_empty() {
+            used.insert(NameKind::Var);
+        }
+        if !self.const_pat.is_empty() {
+            used.insert(NameKind::Const);
+        }
+        if !self.any_pat.is_empty() {
+            used.insert(NameKind::Any);
+        }
+        used
+    }
+
+    fn has_conflicts(&self) -> bool {
+        self.used_patterns().len() > 1
+    }
+
+    fn all_spans_sorted(&self) -> Vec<(NameKind, Span)> {
+        let mut spans =
+            Vec::with_capacity(self.var_pat.len() + self.const_pat.len() + self.any_pat.len());
+        spans.extend(self.var_pat.iter().map(|sp| (NameKind::Var, *sp)));
+        spans.extend(self.const_pat.iter().map(|sp| (NameKind::Const, *sp)));
+        spans.extend(self.any_pat.iter().map(|sp| (NameKind::Any, *sp)));
+        spans.sort_by(|a, b| a.1.cmp(&b.1));
+        spans
+    }
+}
+
+#[derive(Default)]
+pub struct SimilarNamesLinter<'a> {
+    names: BTreeMap<&'a str, NameCollection>,
+}
+
+impl<'a> SimilarNamesLinter<'a> {
+    fn check_names(self) -> Vec<Diagnostic> {
+        self.names
+            .into_iter()
+            .filter_map(|(name, collection)| {
+                if !collection.has_conflicts() {
+                    return None;
+                }
+
+                let mut spans = collection.all_spans_sorted().into_iter();
+
+                let (first_kind, first_span) = spans.next().unwrap();
+
+                let other_spans: Vec<_> =
+                    spans.filter(|(kind, _span)| kind != &first_kind).collect();
+
+                let other_kinds: BTreeSet<_> =
+                    other_spans.iter().map(|(kind, _span)| kind).collect();
+                let num_other_kinds = other_kinds.len();
+                let mut other_kinds = other_kinds.into_iter();
+
+                let other_kinds = if num_other_kinds == 1 {
+                    other_kinds.next().unwrap().to_string()
+                } else {
+                    format!(
+                        "{} and {}",
+                        other_kinds.next().unwrap(),
+                        other_kinds.next().unwrap()
+                    )
+                };
+
+                let mut diag = Diagnostic::span_warn(
+                    first_span,
+                    format!("Similar name \"{}\" used by multiple patterns", name),
+                    Self::CODE,
+                    if other_spans.len() == 1 {
+                        if other_kinds.starts_with('a') {
+                            format!("\"{}\" is used by an {} pattern as well", name, other_kinds)
+                        } else {
+                            format!("\"{}\" is used by a {} pattern as well", name, other_kinds)
+                        }
+                    } else {
+                        format!("\"{}\" is used by {} patterns as well", name, other_kinds)
+                    },
+                );
+
+                for (kind, span) in other_spans.iter() {
+                    diag = diag.with_spanned_note(*span, format!("{} pattern here", kind))
+                }
+
+                Some(diag)
+            })
+            .collect()
+    }
+}
+
+impl<'a> ExprPatVisitor<'a> for SimilarNamesLinter<'a> {
+    fn visit_var_pat(&mut self, var_pat: &'a str, span: Span) {
+        let name = &var_pat[1..];
+        self.names.entry(name).or_default().var_pat.push(span);
+    }
+
+    fn visit_const_pat(&mut self, const_pat: &'a str, span: Span) {
+        let name = &const_pat[1..];
+        self.names.entry(name).or_default().const_pat.push(span);
+    }
+
+    fn visit_any_pat(&mut self, any_pat: &'a str, span: Span) {
+        let name = &any_pat[1..];
+        self.names.entry(name).or_default().any_pat.push(span);
+    }
+}
+
+impl<'a> LintRule<'a, InternedExprPat> for SimilarNamesLinter<'a> {
+    fn lint(expr_pat: &InternedExprPat, _source: &'a str) -> Vec<Diagnostic> {
+        let mut linter = Self::default();
+        linter.visit(expr_pat);
+        linter.check_names()
+    }
+}

--- a/libslide/src/linter/stmt.rs
+++ b/libslide/src/linter/stmt.rs
@@ -1,0 +1,40 @@
+//! Lints for a statement in a slide program.
+
+mod redundant_nesting;
+mod unary_series;
+use redundant_nesting::*;
+use unary_series::*;
+
+use super::{LintExplanation, LintRule};
+use crate::diagnostics::Diagnostic;
+use crate::grammar::Stmt;
+
+use std::collections::HashMap;
+
+macro_rules! define_stmt_lints {
+    ($($linter:ident,)*) => {
+        /// A lint rule applying to a statement in a slide program.
+        pub enum StmtLintRule {
+            $($linter),*
+        }
+
+        impl StmtLintRule {
+            pub fn lint(&self, stmt: &Stmt, source: &str) -> Vec<Diagnostic> {
+                match self {
+                    $(Self::$linter => $linter::lint(stmt, source)),*
+                }
+            }
+
+            pub fn all_explanations() -> HashMap<&'static str, &'static str> {
+                let mut map = HashMap::new();
+                $(map.insert($linter::CODE, $linter::EXPLANATION);)*
+                map
+            }
+        }
+    };
+}
+
+define_stmt_lints! {
+    UnarySeriesLinter,
+    RedundantNestingLinter,
+}

--- a/libslide/src/linter/stmt/redundant_nesting.rs
+++ b/libslide/src/linter/stmt/redundant_nesting.rs
@@ -1,0 +1,81 @@
+explain_lint! {
+    ///The redundant nesting lint detects redundant nesting of expressions in parantheses or
+    ///brackets.
+    ///
+    ///For example, the following nestings are redundant and can be reduced to a single nesting:
+    ///
+    ///```text
+    ///((1))     -> (1)
+    ///[[1]]     -> [1]
+    ///([[(1)]]) -> (1)
+    ///```
+    ///
+    ///Redundant nestings are difficult to read and may be misleading, as generally a single nesting
+    ///is expected to host an expression for precedence or clarity reasons.
+    L0001: RedundantNestingLinter
+}
+
+use crate::linter::LintRule;
+
+use crate::common::Span;
+use crate::diagnostics::Diagnostic;
+use crate::grammar::*;
+
+pub struct RedundantNestingLinter<'a> {
+    source: &'a str,
+    diagnostics: Vec<Diagnostic>,
+}
+
+impl<'a> RedundantNestingLinter<'a> {
+    pub fn new(source: &'a str) -> Self {
+        Self {
+            source,
+            diagnostics: vec![],
+        }
+    }
+}
+
+impl<'a> RedundantNestingLinter<'a> {
+    fn visit_nesting(&mut self, mut expr: &'a InternedExpr, span: Span) {
+        let mut nestings = 1;
+        while let Expr::Parend(inner) | Expr::Bracketed(inner) = expr.as_ref() {
+            expr = inner;
+            nestings += 1;
+        }
+
+        if nestings > 1 {
+            let opener = &self.source[span.lo..span.lo + 1];
+            let closer = &self.source[span.hi - 1..span.hi];
+            let inner_expr = &self.source[expr.span.lo..expr.span.hi];
+
+            self.diagnostics.push(
+                Diagnostic::span_warn(span, "Redundant nesting", Self::CODE, None).with_help(
+                    format!(
+                        r#"consider reducing this expression to "{}{}{}""#,
+                        opener, inner_expr, closer
+                    ),
+                ),
+            )
+        }
+
+        self.visit_expr(expr);
+    }
+}
+
+impl<'a> StmtVisitor<'a> for RedundantNestingLinter<'a> {
+    fn visit_parend(&mut self, expr: &'a InternedExpr, span: Span) {
+        self.visit_nesting(expr, span);
+    }
+
+    fn visit_bracketed(&mut self, expr: &'a InternedExpr, span: Span) {
+        self.visit_nesting(expr, span);
+    }
+}
+
+impl<'a> LintRule<'a, Stmt> for RedundantNestingLinter<'a> {
+    fn lint(stmt: &Stmt, source: &'a str) -> Vec<Diagnostic> {
+        let mut linter = Self::new(&source);
+        linter.visit(stmt);
+        linter.diagnostics
+    }
+}

--- a/libslide/src/linter/stmt/unary_series.rs
+++ b/libslide/src/linter/stmt/unary_series.rs
@@ -1,0 +1,80 @@
+explain_lint! {
+    ///The unary series lint detects trivially-reducible chains of unary operators.
+    ///
+    ///For example, the following chains of unary expressions can be reduced to a more trivial form:
+    ///
+    ///```text
+    ///---1   -> -1
+    ///+++1   ->  1
+    ///+-+-+- -> -1
+    ///```
+    ///
+    ///Chaining unary operators is not standard style in mathematical expressions and can be
+    ///misleading. For example, `--x` may be interpreted to be the prefix decrement operator available
+    ///in some computer programming languages, which is absent in canonical mathematical notation.
+    L0002: UnarySeriesLinter
+}
+
+use crate::linter::LintRule;
+
+use crate::common::Span;
+use crate::diagnostics::Diagnostic;
+use crate::grammar::*;
+
+pub struct UnarySeriesLinter<'a> {
+    source: &'a str,
+    diagnostics: Vec<Diagnostic>,
+}
+
+impl<'a> UnarySeriesLinter<'a> {
+    pub fn new(source: &'a str) -> Self {
+        Self {
+            source,
+            diagnostics: vec![],
+        }
+    }
+}
+
+impl<'a> StmtVisitor<'a> for UnarySeriesLinter<'a> {
+    fn visit_unary(&mut self, expr: &'a UnaryExpr<InternedExpr>, start_span: Span) {
+        let mut is_neg = expr.op == UnaryOperator::SignNegative;
+        let mut nested = &expr.rhs;
+        let mut count = 1;
+        while let Expr::UnaryExpr(UnaryExpr { op, rhs }) = nested.as_ref() {
+            if op == &UnaryOperator::SignNegative {
+                is_neg = !is_neg;
+            }
+            nested = rhs;
+            count += 1;
+        }
+
+        if count > 1 {
+            let span = start_span.to(nested.span);
+            let inner_expr = &self.source[nested.span.lo..nested.span.hi];
+            let reduced_expr = format!("{}{}", if is_neg { "-" } else { "" }, inner_expr);
+
+            self.diagnostics.push(
+                Diagnostic::span_warn(
+                    span,
+                    "Trivially reducible unary operator chain",
+                    Self::CODE,
+                    None,
+                )
+                .with_help(format!(
+                    r#"consider reducing this expression to "{}""#,
+                    reduced_expr
+                )),
+            )
+        }
+
+        self.visit_expr(nested);
+    }
+}
+
+impl<'a> LintRule<'a, Stmt> for UnarySeriesLinter<'a> {
+    fn lint(stmt: &Stmt, source: &'a str) -> Vec<Diagnostic> {
+        let mut linter = Self::new(&source);
+        linter.visit(stmt);
+        linter.diagnostics
+    }
+}

--- a/libslide/src/parser.rs
+++ b/libslide/src/parser.rs
@@ -55,9 +55,10 @@ fn unclosed_delimiter(open: Token, expected: TT, found: Token) -> Diagnostic {
     Diagnostic::span_err(
         found.span,
         format!("Expected `{}`, found {}", expected, found_str),
+        /* TODO: add error code */ None,
         format!("expected closing `{}`", expected),
     )
-    .with_help_note(open.span, format!("opening `{}` here", open))
+    .with_spanned_help(open.span, format!("opening `{}` here", open))
 }
 
 /// Returns a diagnostic for extra tokens following a primary item.
@@ -73,6 +74,7 @@ fn extra_tokens_diag(extra_tokens: &mut PeekIter<Token>) -> Diagnostic {
     Diagnostic::span_err(
         lo..hi,
         "Unexpected extra tokens",
+        /* TODO: add error code */ None,
         "not connected to a primary expression".to_string(),
     )
 }
@@ -158,6 +160,7 @@ where
             self.push_diag(Diagnostic::span_err(
                 tok.span,
                 "Expected an expression, found end of file",
+                /* TODO: add error code */ None,
                 Some("expected an expression".into()),
             ));
             return Self::Expr::empty(tok.span);
@@ -180,6 +183,7 @@ where
                     self.push_diag(Diagnostic::span_err(
                         tok.span,
                         format!("Expected an expression, found `{}`", tok.to_string()),
+                        /* TODO: add error code */ None,
                         Some("expected an expression".into()),
                     ));
                     Self::Expr::empty(tok.span)

--- a/libslide/src/parser/expression_parser.rs
+++ b/libslide/src/parser/expression_parser.rs
@@ -31,6 +31,7 @@ impl ExpressionParser {
             Diagnostic::span_err(
                 span,
                 "Patterns cannot be used in an expression",
+                /* TODO: add error code */ None,
                 Some("unexpected pattern".into()),
             )
             .with_help(format!(

--- a/libslide/src/parser/expression_pattern_parser.rs
+++ b/libslide/src/parser/expression_pattern_parser.rs
@@ -52,6 +52,7 @@ impl Parser<InternedExprPat> for ExpressionPatternParser {
             Diagnostic::span_err(
                 span,
                 "Variables cannot be used in an expression pattern",
+                /* TODO: add error code */ None,
                 Some("unexpected variable".into()),
             )
             .with_help(format!(

--- a/libslide/src/scanner.rs
+++ b/libslide/src/scanner.rs
@@ -114,8 +114,13 @@ impl Scanner {
         let span = start..self.pos;
 
         if matches!(ty, Invalid(..)) {
-            let diag = Diagnostic::span_err(span.clone(), "Invalid token", None)
-                .with_note("token must be mathematically significant");
+            let diag = Diagnostic::span_err(
+                span.clone(),
+                "Invalid token",
+                /* TODO: add error code */ None,
+                None,
+            )
+            .with_note("token must be mathematically significant");
             self.push_diag(diag);
         }
         self.output.push(tok!(ty, span));

--- a/slide/src/lib.rs
+++ b/slide/src/lib.rs
@@ -8,12 +8,13 @@
 mod test;
 
 mod diagnostics;
-use diagnostics::emit_slide_diagnostics;
+use diagnostics::{emit_slide_diagnostics, sanitize_source_for_diagnostics};
 
 use libslide::diagnostics::Diagnostic;
 use libslide::scanner::ScanResult;
 use libslide::{
-    evaluate, parse_expression, parse_expression_pattern, scan, Emit, EvaluatorContext,
+    evaluate, lint_expr_pat, lint_stmt, parse_expression, parse_expression_pattern, scan, Emit,
+    EmitConfig, EmitFormat, EvaluatorContext, LintConfig, Token,
 };
 
 #[cfg(feature = "wasm")]
@@ -35,16 +36,21 @@ pub struct Opts {
     pub emit_format: String,
     /// Configuration options for slide emit.
     pub emit_config: Vec<String>,
+    /// When true, lint warnings for the program will be emitted, if any.
+    pub lint: bool,
     /// When true, slide will stop after parsing a program.
     pub parse_only: bool,
     /// When true, slide will expect the program to be an expression pattern.
     pub expr_pat: bool,
+    /// When is [Some][Option::Some], will explain a diagnostic code.
+    pub explain_diagnostic: Option<String>,
     /// When true, slide emit will be colored.
     pub color: bool,
 }
 
 /// Output of a slide execution.
 #[cfg_attr(feature = "wasm", derive(Serialize, Deserialize))]
+#[derive(Default)]
 pub struct SlideResult {
     /// Exit code
     pub code: i32,
@@ -52,60 +58,198 @@ pub struct SlideResult {
     pub stdout: String,
     /// Emit for stderr
     pub stderr: String,
+    /// Whether the stdout should be emit as paged
+    pub page: bool,
+}
+
+/// Builds a [SlideResult][SlideResult].
+struct SlideResultBuilder<'a> {
+    /// File the program is defined in. [None][Option::None] if the program comes from a side
+    /// channel like stdin.
+    file: Option<&'a str>,
+    /// Original slide program source code.
+    org_program: &'a str,
+    /// Program source code sanitized for diagnostic emission.
+    sanitized_program: String,
+    emit_format: EmitFormat,
+    emit_config: EmitConfig,
+    color: bool,
+    stdout: String,
+    stderr: String,
+    page: bool,
+}
+
+impl<'a> SlideResultBuilder<'a> {
+    fn new(
+        file: Option<&'a str>,
+        program: &'a str,
+        emit_format: impl Into<EmitFormat>,
+        emit_config: impl Into<EmitConfig>,
+        color: bool,
+    ) -> Self {
+        Self {
+            file,
+            org_program: program,
+            sanitized_program: sanitize_source_for_diagnostics(program),
+            emit_format: emit_format.into(),
+            emit_config: emit_config.into(),
+            color,
+            page: false,
+            stdout: String::new(),
+            stderr: String::new(),
+        }
+    }
+
+    fn emit(&mut self, obj: &dyn Emit) {
+        self.stdout
+            .push_str(&obj.emit(self.emit_format, self.emit_config));
+    }
+
+    fn err(&mut self, diagnostics: &[Diagnostic]) {
+        self.stderr.push_str(&emit_slide_diagnostics(
+            self.file,
+            &self.sanitized_program,
+            diagnostics,
+            self.color,
+        ));
+    }
+
+    fn page(&mut self, page: bool) {
+        self.page = page;
+    }
+
+    fn ok(self) -> SlideResult {
+        SlideResult {
+            code: 0,
+            stdout: self.stdout,
+            stderr: self.stderr,
+            page: self.page,
+        }
+    }
+
+    fn failed(self) -> SlideResult {
+        SlideResult {
+            code: 1,
+            stdout: self.stdout,
+            stderr: self.stderr,
+            page: self.page,
+        }
+    }
 }
 
 /// Runs slide end-to-end.
 pub fn run_slide(opts: Opts) -> SlideResult {
-    let Opts {
-        emit_format,
-        emit_config,
-        program,
-        color,
-        ..
-    } = opts;
-    let file = None; // currently programs can only be read from stdin
+    let mut result = SlideResultBuilder::new(
+        None, // file: currently programs can only be read from stdin
+        &opts.program,
+        opts.emit_format,
+        opts.emit_config,
+        opts.color,
+    );
 
-    let emit_diagnostics = |diagnostics: Vec<Diagnostic>| SlideResult {
-        code: 1,
-        stdout: String::new(),
-        stderr: emit_slide_diagnostics(file, program.clone(), diagnostics, color),
-    };
-    let emit_tree = move |obj: &dyn Emit| SlideResult {
-        code: 0,
-        stdout: obj.emit(emit_format.into(), emit_config.into()),
-        stderr: String::new(),
-    };
+    if let Some(diag_code) = opts.explain_diagnostic {
+        let codes = LintConfig::all_codes_with_explanations();
+        return match codes.get::<str>(&diag_code) {
+            Some(explanation) => {
+                result.stdout.push_str(&explanation);
+                result.page(true);
+                result.ok()
+            }
+            None => {
+                result
+                    .stderr
+                    .push_str(&format!("{} is not a diagnostic code", diag_code));
+                result.failed()
+            }
+        };
+    }
 
     let ScanResult {
         tokens,
         diagnostics,
-    } = scan(&*program);
+    } = scan(&*opts.program);
+    result.err(&diagnostics);
     if !diagnostics.is_empty() {
-        return emit_diagnostics(diagnostics);
+        return result.failed();
     }
+
+    let evaluator = ProgramEvaluator::new(result, tokens, opts.lint, opts.parse_only);
 
     if opts.expr_pat {
-        let (parse_tree, diagnostics) = parse_expression_pattern(tokens);
+        evaluator.eval_expr_pat()
+    } else {
+        evaluator.eval_slide_program()
+    }
+}
+
+/// Evaluates a slide program either as a regular program or an expression pattern.
+struct ProgramEvaluator<'a> {
+    result: SlideResultBuilder<'a>,
+    tokens: Vec<Token>,
+    lint: bool,
+    parse_only: bool,
+}
+
+impl<'a> ProgramEvaluator<'a> {
+    fn new(
+        result: SlideResultBuilder<'a>,
+        tokens: Vec<Token>,
+        lint: bool,
+        parse_only: bool,
+    ) -> Self {
+        Self {
+            result,
+            tokens,
+            lint,
+            parse_only,
+        }
+    }
+
+    /// Handles evaluation of a regular slide program (statements, expressions).
+    fn eval_slide_program(mut self) -> SlideResult {
+        let (parse_tree, diagnostics) = parse_expression(self.tokens);
+
+        self.result.err(&diagnostics);
         if !diagnostics.is_empty() {
-            return emit_diagnostics(diagnostics);
+            return self.result.failed();
         }
-        if opts.parse_only {
-            return emit_tree(&parse_tree);
+
+        if self.lint {
+            self.result
+                .err(&lint_stmt(&parse_tree, self.result.org_program));
         }
-        unreachable!();
-    }
-    let (parse_tree, diagnostics) = parse_expression(tokens);
 
-    if !diagnostics.is_empty() {
-        return emit_diagnostics(diagnostics);
+        if self.parse_only {
+            self.result.emit(&parse_tree);
+        } else {
+            let simplified = evaluate(parse_tree, &EvaluatorContext::default()).unwrap();
+            self.result.emit(&simplified);
+        }
+
+        self.result.ok()
     }
 
-    if opts.parse_only {
-        return emit_tree(&parse_tree);
-    }
+    /// Handles evaluation of a slide expression pattern.
+    fn eval_expr_pat(mut self) -> SlideResult {
+        let (parse_tree, diagnostics) = parse_expression_pattern(self.tokens);
+        self.result.err(&diagnostics);
+        if !diagnostics.is_empty() {
+            return self.result.failed();
+        }
 
-    let simplified = evaluate(parse_tree, &EvaluatorContext::default()).unwrap();
-    emit_tree(&simplified)
+        if self.lint {
+            self.result
+                .err(&lint_expr_pat(&parse_tree, self.result.org_program));
+        }
+
+        if self.parse_only {
+            self.result.emit(&parse_tree);
+        } else {
+            panic!("Expression patterns can only be parsed.");
+        }
+
+        self.result.ok()
+    }
 }
 
 /// Runs slide through a wasm entry point.

--- a/slide/src/main.rs
+++ b/slide/src/main.rs
@@ -1,6 +1,8 @@
 use slide::{run_slide, Opts, SlideResult};
 use std::env;
+use std::ffi::OsString;
 use std::io::Write;
+use std::process::{Command, Stdio};
 use termcolor::{BufferedStandardStream, ColorChoice, WriteColor};
 
 fn get_opts(color: bool) -> Opts {
@@ -11,7 +13,8 @@ fn get_opts(color: bool) -> Opts {
         .arg(
             clap::Arg::with_name("program")
                 .help("Program to evaluate")
-                .required(true),
+                .required(true)
+                .default_value_if("explain", None, "")
         )
         .arg(
             clap::Arg::with_name("output-form")
@@ -47,6 +50,11 @@ fn get_opts(color: bool) -> Opts {
                 .multiple(true),
         )
         .arg(
+            clap::Arg::with_name("lint")
+                .long("--lint")
+                .help("Emit lint warnings for the program, if any."),
+        )
+        .arg(
             clap::Arg::with_name("parse-only")
                 .long("--parse-only")
                 .help("Stop after parsing and dump the AST"),
@@ -55,6 +63,13 @@ fn get_opts(color: bool) -> Opts {
             clap::Arg::with_name("expr-pat")
                 .long("--expr-pat")
                 .help("Parse the program as an expression pattern. Implies --parse-only."),
+        )
+        .arg(
+            clap::Arg::with_name("explain")
+                .long("--explain")
+                .value_name("diagnostic")
+                .help("Provide a detailed explanation for a diagnostic code.")
+                .takes_value(true)
         )
         .get_matches();
 
@@ -67,7 +82,9 @@ fn get_opts(color: bool) -> Opts {
             .values_of("emit-config")
             .map(|opts| opts.map(str::to_owned).collect())
             .unwrap_or_default(),
+        lint: matches.is_present("lint"),
         parse_only: matches.is_present("parse-only") || expr_pat,
+        explain_diagnostic: matches.value_of("explain").map(str::to_owned),
         expr_pat,
         color,
     }
@@ -76,25 +93,65 @@ fn get_opts(color: bool) -> Opts {
 fn main_impl() -> Result<(), Box<dyn std::error::Error>> {
     let mut ch_stdout = BufferedStandardStream::stdout(ColorChoice::Auto);
     let mut ch_stderr = BufferedStandardStream::stderr(ColorChoice::Auto);
-    let use_color = atty::is(atty::Stream::Stderr) && ch_stderr.supports_color();
+    let is_tty = atty::is(atty::Stream::Stderr);
+    let use_color = is_tty && ch_stderr.supports_color();
 
     let opts = get_opts(use_color);
     let SlideResult {
         code,
         stdout,
         stderr,
+        page,
     } = run_slide(opts);
 
-    if !stdout.is_empty() {
-        writeln!(&mut ch_stdout, "{}", stdout)?;
-        ch_stdout.flush()?;
-    }
     if !stderr.is_empty() {
         writeln!(&mut ch_stderr, "{}", stderr)?;
         ch_stderr.flush()?;
     }
+    if !stdout.is_empty() {
+        print_stdout(&stdout, &mut ch_stdout, page)?;
+    }
 
     std::process::exit(code)
+}
+
+/// Basically just copied from rust/src/librustc_driver/lib.rs#show_content_with_pager
+fn print_stdout(
+    stdout: &str,
+    mut ch_stdout: &mut BufferedStandardStream,
+    page: bool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let mut fallback_to_println = false;
+
+    if page {
+        let pager_name = env::var_os("PAGER")
+            .unwrap_or_else(|| OsString::from(if cfg!(windows) { "more.com" } else { "less" }));
+
+        match Command::new(pager_name).stdin(Stdio::piped()).spawn() {
+            Ok(mut pager) => {
+                if let Some(pipe) = pager.stdin.as_mut() {
+                    if pipe.write_all(stdout.as_bytes()).is_err() {
+                        fallback_to_println = true;
+                    }
+                }
+
+                if pager.wait().is_err() {
+                    fallback_to_println = true;
+                }
+            }
+            Err(_) => {
+                fallback_to_println = true;
+            }
+        }
+    }
+
+    // If pager fails for whatever reason, we should still print the content to standard output.
+    if fallback_to_println || !page {
+        writeln!(&mut ch_stdout, "{}", stdout)?;
+        ch_stdout.flush()?;
+    }
+
+    Ok(())
 }
 
 fn main() {

--- a/slide/src/test/ui/cli/help.slide
+++ b/slide/src/test/ui/cli/help.slide
@@ -16,6 +16,7 @@ USAGE:
 FLAGS:
         --expr-pat      Parse the program as an expression pattern. Implies --parse-only.
     -h, --help          Prints help information
+        --lint          Emit lint warnings for the program, if any.
         --parse-only    Stop after parsing and dump the AST
     -V, --version       Prints version information
 
@@ -23,6 +24,7 @@ OPTIONS:
         --emit-config <emit-config>...
             Emit configuration options. Possible values:
             	frac (latex): Emit divisions as fractions.
+        --explain <diagnostic>            Provide a detailed explanation for a diagnostic code.
     -o, --output-form <output-form>
             Slide emit format. Possible values:
             	pretty:       Human-readable text, like "1 + 2".

--- a/slide/src/test/ui/lint/redundant_nesting_explained.slide
+++ b/slide/src/test/ui/lint/redundant_nesting_explained.slide
@@ -1,0 +1,29 @@
+!!!args
+---explain L0001
+!!!args
+
+===in
+===in
+
+~~~stdout
+The redundant nesting lint detects redundant nesting of expressions in parantheses or
+brackets.
+
+For example, the following nestings are redundant and can be reduced to a single nesting:
+
+```text
+((1))     -> (1)
+[[1]]     -> [1]
+([[(1)]]) -> (1)
+```
+
+Redundant nestings are difficult to read and may be misleading, as generally a single nesting
+is expected to host an expression for precedence or clarity reasons.
+~~~stdout
+
+~~~stderr
+~~~stderr
+
+~~~exitcode
+0
+~~~exitcode

--- a/slide/src/test/ui/lint/redundant_nesting_lint.slide
+++ b/slide/src/test/ui/lint/redundant_nesting_lint.slide
@@ -1,0 +1,39 @@
+!!!args
+--lint
+!!!args
+
+===in
+( ((1   +    [[  [2    /     ([([4])])]]]  )))
+===in
+
+~~~stdout
+1.5
+~~~stdout
+
+~~~stderr
+warning[L0001]: Redundant nesting
+  |
+1 | ( ((1   +    [[  [2    /     ([([4])])]]]  ))) 
+  | ----------------------------------------------
+  |
+  = help: consider reducing this expression to "(1   +    [[  [2    /     ([([4])])]]])"
+
+warning[L0001]: Redundant nesting
+  |
+1 | ( ((1   +    [[  [2    /     ([([4])])]]]  ))) 
+  |              ----------------------------
+  |
+  = help: consider reducing this expression to "[2    /     ([([4])])]"
+
+warning[L0001]: Redundant nesting
+  |
+1 | ( ((1   +    [[  [2    /     ([([4])])]]]  ))) 
+  |                              ---------
+  |
+  = help: consider reducing this expression to "(4)"
+
+~~~stderr
+
+~~~exitcode
+0
+~~~exitcode

--- a/slide/src/test/ui/lint/redundant_nesting_nolint.slide
+++ b/slide/src/test/ui/lint/redundant_nesting_nolint.slide
@@ -1,0 +1,18 @@
+!!!args
+--lint
+!!!args
+
+===in
+(1   +    [  2    /     (4)]  )
+===in
+
+~~~stdout
+1.5
+~~~stdout
+
+~~~stderr
+~~~stderr
+
+~~~exitcode
+0
+~~~exitcode

--- a/slide/src/test/ui/lint/similar_name_explained.slide
+++ b/slide/src/test/ui/lint/similar_name_explained.slide
@@ -1,0 +1,30 @@
+!!!args
+---explain L0003
+!!!args
+
+===in
+===in
+
+~~~stdout
+The similar names lint detects expression patterns with very similar names.
+
+For example, the following pattern expression has different patterns with the same suffix "a":
+
+```text
+$a + #a + _a + $a
+```
+
+While this is expression is semantically valid, it can be difficuly to read and misleading,
+since "a" is used in three separate and independent patterns. A clearer expression would be
+
+```text
+$a + #b + _c + $a
+```
+~~~stdout
+
+~~~stderr
+~~~stderr
+
+~~~exitcode
+0
+~~~exitcode

--- a/slide/src/test/ui/lint/similar_name_lint.slide
+++ b/slide/src/test/ui/lint/similar_name_lint.slide
@@ -1,0 +1,87 @@
+!!!args
+--lint
+--expr-pat
+!!!args
+
+===in
+_a + #a + _a + $a + #b +
+#a + _b + $b + #b + $b +
+$c + _c + #c + $c + _a +
+_d + #d + #d +
+$e + _e +
+#f + $f +
+_gosh + #gosh
+===in
+
+~~~stdout
+_a + #a + _a + $a + #b + #a + _b + $b + #b + $b + $c + _c + #c + $c + _a + _d + #d + #d + $e + _e + #f + $f + _gosh + #gosh
+~~~stdout
+
+~~~stderr
+warning[L0003]: Similar name "a" used by multiple patterns
+  |
+1 | _a + #a + _a + $a + #b +
+  | -- "a" is used by var and const patterns as well
+  |      -- note: const pattern here
+  |                -- note: var pattern here
+2 | #a + _b + $b + #b + $b +
+  | -- note: const pattern here
+  |
+
+warning[L0003]: Similar name "b" used by multiple patterns
+  |
+1 | _a + #a + _a + $a + #b +
+  |                     -- "b" is used by var and any patterns as well
+2 | #a + _b + $b + #b + $b +
+  |      -- note: any pattern here
+  |           -- note: var pattern here
+  |                     -- note: var pattern here
+  |
+
+warning[L0003]: Similar name "c" used by multiple patterns
+  |
+...
+3 | $c + _c + #c + $c + _a +
+  | -- "c" is used by const and any patterns as well
+  |      -- note: any pattern here
+  |           -- note: const pattern here
+  |
+
+warning[L0003]: Similar name "d" used by multiple patterns
+  |
+...
+4 | _d + #d + #d +
+  | -- "d" is used by const patterns as well
+  |      -- note: const pattern here
+  |           -- note: const pattern here
+  |
+
+warning[L0003]: Similar name "e" used by multiple patterns
+  |
+...
+5 | $e + _e +
+  | -- "e" is used by an any pattern as well
+  |      -- note: any pattern here
+  |
+
+warning[L0003]: Similar name "f" used by multiple patterns
+  |
+...
+6 | #f + $f +
+  | -- "f" is used by a var pattern as well
+  |      -- note: var pattern here
+  |
+
+warning[L0003]: Similar name "gosh" used by multiple patterns
+  |
+...
+7 | _gosh + #gosh 
+  | ----- "gosh" is used by a const pattern as well
+  |         ----- note: const pattern here
+  |
+
+~~~stderr
+
+~~~exitcode
+0
+~~~exitcode

--- a/slide/src/test/ui/lint/similar_name_nolint.slide
+++ b/slide/src/test/ui/lint/similar_name_nolint.slide
@@ -1,0 +1,19 @@
+!!!args
+--lint
+--expr-pat
+!!!args
+
+===in
+$a + #aa + _aaa + $b + #ba
+===in
+
+~~~stdout
+$a + #aa + _aaa + $b + #ba
+~~~stdout
+
+~~~stderr
+~~~stderr
+
+~~~exitcode
+0
+~~~exitcode

--- a/slide/src/test/ui/lint/unary_series_explained.slide
+++ b/slide/src/test/ui/lint/unary_series_explained.slide
@@ -1,0 +1,29 @@
+!!!args
+---explain L0002
+!!!args
+
+===in
+===in
+
+~~~stdout
+The unary series lint detects trivially-reducible chains of unary operators.
+
+For example, the following chains of unary expressions can be reduced to a more trivial form:
+
+```text
+---1   -> -1
++++1   ->  1
++-+-+- -> -1
+```
+
+Chaining unary operators is not standard style in mathematical expressions and can be
+misleading. For example, `--x` may be interpreted to be the prefix decrement operator available
+in some computer programming languages, which is absent in canonical mathematical notation.
+~~~stdout
+
+~~~stderr
+~~~stderr
+
+~~~exitcode
+0
+~~~exitcode

--- a/slide/src/test/ui/lint/unary_series_lint.slide
+++ b/slide/src/test/ui/lint/unary_series_lint.slide
@@ -1,0 +1,46 @@
+!!!args
+--lint
+!!!args
+
+===in
+++++(+-+-+-[1 / --2 * (---3)])
+===in
+
+~~~stdout
+1.5
+~~~stdout
+
+~~~stderr
+warning[L0002]: Trivially reducible unary operator chain
+  |
+1 | ++++(+-+-+-[1 / --2 * (---3)]) 
+  | ------------------------------
+  |
+  = help: consider reducing this expression to "(+-+-+-[1 / --2 * (---3)])"
+
+warning[L0002]: Trivially reducible unary operator chain
+  |
+1 | ++++(+-+-+-[1 / --2 * (---3)]) 
+  |      ------------------------
+  |
+  = help: consider reducing this expression to "-[1 / --2 * (---3)]"
+
+warning[L0002]: Trivially reducible unary operator chain
+  |
+1 | ++++(+-+-+-[1 / --2 * (---3)]) 
+  |                 ---
+  |
+  = help: consider reducing this expression to "2"
+
+warning[L0002]: Trivially reducible unary operator chain
+  |
+1 | ++++(+-+-+-[1 / --2 * (---3)]) 
+  |                        ----
+  |
+  = help: consider reducing this expression to "-3"
+
+~~~stderr
+
+~~~exitcode
+0
+~~~exitcode

--- a/slide/src/test/ui/lint/unary_series_nolint.slide
+++ b/slide/src/test/ui/lint/unary_series_nolint.slide
@@ -1,0 +1,18 @@
+!!!args
+--lint
+!!!args
+
+===in
++(-[1 / 2 * (-3)])
+===in
+
+~~~stdout
+1.5
+~~~stdout
+
+~~~stderr
+~~~stderr
+
+~~~exitcode
+0
+~~~exitcode

--- a/www/index.html
+++ b/www/index.html
@@ -131,6 +131,11 @@
                 </div>
               </details>
 
+              <label>
+                <input type="checkbox" class="form-checkbox-details-trigger" v-model="lint" />
+                Lint
+              </label>
+
               <div class="form-checkbox">
                 <label>
                   <input
@@ -146,6 +151,25 @@
                       <input id="expr-pat" name="expr-pat" type="checkbox" v-model="exprPat" />
                       Parse expression pattern
                     </label>
+                  </span>
+                </label>
+              </div>
+
+              <div class="form-checkbox">
+                <label>
+                  <input
+                    type="checkbox"
+                    class="form-checkbox-details-trigger"
+                    v-model="shouldExplain"
+                  />
+                  Explain
+                  <span class="form-checkbox-details text-normal">
+                    <input
+                      class="form-control input-contrast"
+                      size="6"
+                      placeholder="code"
+                      v-model="explain"
+                    />
                   </span>
                 </label>
               </div>
@@ -203,8 +227,11 @@
           }
         }
       }
+      const lint = queryParams.get("lint") === "true";
       const parseOnly = queryParams.get("parse-only") === "true";
       const exprPat = queryParams.get("expr-pat") === "true";
+      const shouldExplain = queryParams.get("shouldExplain") === "true";
+      const explain = queryParams.get("explain") || "";
 
       new Vue({
         el: "#app",
@@ -215,8 +242,11 @@
           emitFormatOptions: ["pretty", "latex", "s-expression", "debug"],
           emitFormat,
           emitConfig,
+          lint,
           parseOnly,
           exprPat,
+          shouldExplain,
+          explain,
           bugReportUrl: BASE_ISSUE_URL,
           ranOnce: false,
           latexEmitImgUrl: "",
@@ -236,7 +266,8 @@
         },
         created() {
           document.querySelector("#slide-input").innerText = this.input;
-          document.querySelector("#options").open = this.emitConfigOptIsSet || this.parseOnly;
+          document.querySelector("#options").open =
+            this.emitConfigOptIsSet || this.lint || this.parseOnly || this.shouldExplain;
           document.querySelector("#emit-config").open = this.emitConfigOptIsSet;
         },
         updated() {
@@ -251,8 +282,11 @@
               LZString.compressToEncodedURIComponent(JSON.stringify(this.emitConfig))
             );
             queryParams.set("emit-format", this.emitFormat);
+            queryParams.set("lint", this.lint);
             queryParams.set("parse-only", this.parseOnly);
             queryParams.set("expr-pat", this.exprPat);
+            queryParams.set("shouldExplain", this.shouldExplain);
+            queryParams.set("explain", this.explain);
             const curUrl = `${window.location.pathname}?${queryParams}`;
             history.replaceState(null, "", curUrl);
           },
@@ -269,14 +303,16 @@
               program: this.input,
               emit_format: this.emitFormat,
               emit_config: Object.keys(this.emitConfig).filter((opt) => this.emitConfig[opt]),
+              lint: this.lint,
               parse_only: this.parseOnly,
               expr_pat: this.exprPat,
+              explain_diagnostic: this.shouldExplain ? this.explain : undefined,
               color: true,
             };
 
             const { code, stdout, stderr } = run_slide_wasm(slideOpts);
 
-            this.output = ansi.ansi_to_html(`${stdout}${stderr}`);
+            this.output = ansi.ansi_to_html(`${stderr}\n${stdout}`).trim();
             this.ranOnce = true;
             this.updateUrl();
             this.updateBugReportUrl(slideOpts);


### PR DESCRIPTION
This commit adds support for a linting framework inside slide, and adds
the following lints:

- unary series
- redundant nestings
- similar names

In the future, we can add more lints and maybe support
enabling/disabling lints.

Closes #135
