### PR TITLE
Support := as an assignment operator

### DIFF
--- a/libslide/src/emit.rs
+++ b/libslide/src/emit.rs
@@ -41,6 +41,9 @@ bitflags::bitflags! {
         /// Emit divisions as fractions.
         /// Applies to LaTeX emit.
         const FRAC = 1;
+        /// Emit assignment operators as ":=".
+        /// Applies to pretty emit.
+        const DEFINE_ASSIGN = 2;
     }
 }
 
@@ -50,6 +53,7 @@ impl From<Vec<String>> for EmitConfig {
         for opt in opts {
             config |= match opt.as_ref() {
                 "frac" => EmitConfig::FRAC,
+                "define-assign" => EmitConfig::DEFINE_ASSIGN,
                 _ => unreachable!(),
             }
         }
@@ -173,7 +177,12 @@ impl Emit for Stmt {
 fmt_emit_impl!(Assignment);
 impl Emit for Assignment {
     fn emit_pretty(&self, config: EmitConfig) -> String {
-        format!("{} = {}", self.var, self.rhs.emit_pretty(config))
+        let assign = if config.contains(EmitConfig::DEFINE_ASSIGN) {
+            ":="
+        } else {
+            "="
+        };
+        format!("{} {} {}", self.var, assign, self.rhs.emit_pretty(config))
     }
 
     fn emit_s_expression(&self, config: EmitConfig) -> String {

--- a/libslide/src/scanner/errors.rs
+++ b/libslide/src/scanner/errors.rs
@@ -45,9 +45,18 @@ define_errors! {
     ///to use notation that is intuitive and obvious. Of course, reasonable people can disagree on
     ///what this means.
     S0001: InvalidToken {
-        ($span:expr) => {
-            Diagnostic::span_err($span, "Invalid token", InvalidToken::CODE, None)
-                .with_note("token must be mathematically significant")
-        }
+        ($span:expr, $did_you_mean:expr) => {{
+            let mut diag = Diagnostic::span_err(
+                $span,
+                "Invalid token",
+                InvalidToken::CODE,
+                None,
+            )
+            .with_note("token must be mathematically significant");
+            if let Some((did_you_mean, span)) = $did_you_mean {
+                diag = diag.with_spanned_help(span, format!(r#"did you mean "{}"?"#, did_you_mean));
+            }
+            diag
+        }}
     }
 }

--- a/slide/src/lib.rs
+++ b/slide/src/lib.rs
@@ -89,12 +89,13 @@ where
                 .next_line_help(true)
                 .help(
                     "Emit configuration options. Possible values:\n\
-                    \tfrac (latex): Emit divisions as fractions.\n\
+                    \tfrac          (latex): Emit divisions as fractions.\n\
+                    \tdefine-assign (pretty): Use \":=\" for assignments.\n\
                     ",
                 )
                 .hide_possible_values(true)
                 .takes_value(true)
-                .possible_values(&["frac"])
+                .possible_values(&["frac", "define-assign"])
                 .multiple(true),
         )
         .arg(

--- a/slide/src/test/ui/cli/help.slide
+++ b/slide/src/test/ui/cli/help.slide
@@ -23,7 +23,8 @@ FLAGS:
 OPTIONS:
         --emit-config <emit-config>...
             Emit configuration options. Possible values:
-            	frac (latex): Emit divisions as fractions.
+            	frac          (latex): Emit divisions as fractions.
+            	define-assign (pretty): Use ":=" for assignments.
         --explain <diagnostic>            Provide a detailed explanation for a diagnostic code.
     -o, --output-form <output-form>
             Slide emit format. Possible values:

--- a/slide/src/test/ui/emit/pretty/define-assign.slide
+++ b/slide/src/test/ui/emit/pretty/define-assign.slide
@@ -1,0 +1,18 @@
+!!!args
+--emit-config=define-assign
+!!!args
+
+===in
+A := 5
+===in
+
+~~~stdout
+A := 5
+~~~stdout
+
+~~~stderr
+~~~stderr
+
+~~~exitcode
+0
+~~~exitcode

--- a/slide/src/test/ui/error/define-assign.slide
+++ b/slide/src/test/ui/error/define-assign.slide
@@ -1,0 +1,20 @@
+===in
+arg :  = 5
+===in
+
+~~~stdout
+~~~stdout
+
+~~~stderr
+error[S0001]: Invalid token
+  |
+1 | arg :  = 5 
+  |     ^
+  |     ---- help: did you mean ":="?
+  |
+  = note: token must be mathematically significant
+~~~stderr
+
+~~~exitcode
+1
+~~~exitcode

--- a/www/index.html
+++ b/www/index.html
@@ -208,6 +208,7 @@
       const DEFAULT_EXAMPLE = "x(x + 2 * 3) / (x + 6)";
       const DEFAULT_EMIT_CONFIG = {
         frac: false,
+        "define-assign": false,
       };
       const BASE_ISSUE_URL = "https://github.com/yslide/slide/issues/new";
 


### PR DESCRIPTION
Often := is used as a definition operator and = used as an equality
operator in mathematical expressions. This commit adds support for := in
assignment contexts.

We will also emit a nice diagnostic for cases like `a : = 5`, where a
user probably meant `a := 5`.
