### PR TITLE
Record leading trivia as full span on tokens

### DIFF
--- a/libslide/src/common.rs
+++ b/libslide/src/common.rs
@@ -29,6 +29,11 @@ impl Span {
             hi: other.hi,
         }
     }
+
+    #[allow(unused)] // TODO: propogate usage
+    pub(crate) fn over<'a>(&self, content: &'a str) -> &'a str {
+        &content[self.lo..self.hi]
+    }
 }
 
 impl PartialOrd for Span {

--- a/libslide/src/parser.rs
+++ b/libslide/src/parser.rs
@@ -176,21 +176,22 @@ where
             }
         };
 
-        let next_span = self.peek().span;
-        match self.peek().ty {
+        let insert_synthetic_mult = match self.peek().ty {
             // <node>(<other>) => <node> * (<other>)
-            TT::OpenParen | TT::OpenBracket => {
-                self.input()
-                    .push_front(Token::new(TT::Mult, (tok_span.hi, next_span.lo)));
-            }
+            TT::OpenParen | TT::OpenBracket => true,
             // <num><var> => <num> * <var>
             TT::Variable(_) | TT::VariablePattern(_) | TT::ConstPattern(_) | TT::AnyPattern(_)
                 if node.is_const() =>
             {
-                self.input()
-                    .push_front(Token::new(TT::Mult, (tok_span.hi, next_span.lo)))
+                true
             }
-            _ => {}
+            _ => false,
+        };
+        if insert_synthetic_mult {
+            let next_span = self.peek().span;
+            let bw_cur_and_next = (tok_span.hi, next_span.lo);
+            self.input()
+                .push_front(Token::new(TT::Mult, bw_cur_and_next, bw_cur_and_next));
         }
 
         node

--- a/libslide/src/scanner/types.rs
+++ b/libslide/src/scanner/types.rs
@@ -98,17 +98,21 @@ pub struct Token {
     pub ty: TokenType,
     /// The source span of the token.
     pub span: Span,
+    /// The full span of the token including its leading trivia.
+    pub full_span: Span,
 }
 
 impl Token {
     /// Creates a new token.
-    pub fn new<S>(ty: TokenType, span: S) -> Self
+    pub fn new<Sp1, Sp2>(ty: TokenType, span: Sp1, full_span: Sp2) -> Self
     where
-        S: Into<Span>,
+        Sp1: Into<Span>,
+        Sp2: Into<Span>,
     {
         Self {
             ty,
             span: span.into(),
+            full_span: full_span.into(),
         }
     }
 }
@@ -130,7 +134,7 @@ mod tests {
                 #[test]
                 fn $name() {
                     use TokenType::*;
-                    let tok = Token {ty: $ty, span: (0, 0).into()};
+                    let tok = Token::new($ty, (0..0), (0..0));
                     assert_eq!(tok.to_string(), $format_str);
                 }
             )*


### PR DESCRIPTION
This will be used to distinguish newline-separated statements in a
future patch adding support for statement delimination across multiple
lines. That is, we want

```
1 + 2
2 + 3
```

to parse as two expression statements, but

```
1 + 2 2 + 3
```

not to do so.

To support this, we need information about whether the start of an
expression is preceded by a newline, which leading trivia information
will provide.
