### PR TITLE
Support multiple statements across new lines

### DIFF
--- a/libslide/src/emit.rs
+++ b/libslide/src/emit.rs
@@ -148,6 +148,29 @@ macro_rules! latex_wrap {
     };
 }
 
+#[inline]
+fn join_emits<'a, E: 'a + Emit>(
+    list: impl Iterator<Item = &'a E>,
+    emit: impl FnMut(&E) -> String,
+) -> String {
+    list.map(emit).collect::<Vec<_>>().join("\n")
+}
+
+fmt_emit_impl!(StmtList);
+impl Emit for StmtList {
+    fn emit_pretty(&self, config: EmitConfig) -> String {
+        join_emits(self.iter(), |s| s.emit_pretty(config))
+    }
+
+    fn emit_s_expression(&self, config: EmitConfig) -> String {
+        join_emits(self.iter(), |s| s.emit_s_expression(config))
+    }
+
+    fn emit_latex(&self, config: EmitConfig) -> String {
+        join_emits(self.iter(), |s| s.emit_latex(config))
+    }
+}
+
 fmt_emit_impl!(Stmt);
 impl Emit for Stmt {
     fn emit_pretty(&self, config: EmitConfig) -> String {

--- a/libslide/src/grammar/statement.rs
+++ b/libslide/src/grammar/statement.rs
@@ -1,5 +1,47 @@
 use super::*;
 
+/// A list of statements in a slide program.
+#[derive(Clone, Debug)]
+pub struct StmtList {
+    /// The list of statements.
+    list: Vec<Stmt>,
+}
+
+impl Grammar for StmtList {}
+
+impl StmtList {
+    pub(crate) fn new(list: Vec<Stmt>) -> Self {
+        Self { list }
+    }
+
+    pub(crate) fn iter(&self) -> std::slice::Iter<'_, Stmt> {
+        self.list.iter()
+    }
+}
+
+pub struct StmtListIterator {
+    stmts: <Vec<Stmt> as IntoIterator>::IntoIter,
+}
+
+impl Iterator for StmtListIterator {
+    type Item = Stmt;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.stmts.next()
+    }
+}
+
+impl IntoIterator for StmtList {
+    type Item = Stmt;
+    type IntoIter = StmtListIterator;
+
+    fn into_iter(self) -> Self::IntoIter {
+        Self::IntoIter {
+            stmts: self.list.into_iter(),
+        }
+    }
+}
+
 /// A statement in a slide program.
 #[derive(Clone, Debug)]
 pub enum Stmt {

--- a/libslide/src/lib.rs
+++ b/libslide/src/lib.rs
@@ -202,7 +202,7 @@
 
 #[macro_use]
 mod grammar;
-pub use grammar::{ExprPat, Grammar, Stmt};
+pub use grammar::{ExprPat, Grammar, Stmt, StmtList};
 
 mod common;
 pub use common::*;

--- a/libslide/src/linter.rs
+++ b/libslide/src/linter.rs
@@ -19,7 +19,7 @@ mod expr_pat;
 use expr_pat::*;
 
 use crate::diagnostics::{Diagnostic, DiagnosticRecord, DiagnosticRegistry};
-use crate::grammar::{Grammar, InternedExprPat, Stmt};
+use crate::grammar::{Grammar, InternedExprPat, StmtList};
 
 /// Describes a slide program linter. A `Linter` is implemented on a slide [Grammar].
 ///
@@ -61,12 +61,14 @@ impl DiagnosticRegistry for LintConfig {
     }
 }
 
-/// Lints a slide [statement](crate::grammar::Stmt).
-pub fn lint_stmt(stmt: &Stmt, source: &str) -> Vec<Diagnostic> {
+/// Lints a slide [statement list](crate::grammar::StmtList).
+pub fn lint_stmt(stmt_list: &StmtList, source: &str) -> Vec<Diagnostic> {
     let config = LintConfig::default();
     let mut diags = vec![];
-    for linter in config.stmt_linters {
-        diags.extend(linter.lint(stmt, source))
+    for stmt in stmt_list.iter() {
+        for linter in config.stmt_linters.iter() {
+            diags.extend(linter.lint(stmt, source))
+        }
     }
     diags
 }

--- a/libslide/src/parser.rs
+++ b/libslide/src/parser.rs
@@ -83,7 +83,7 @@ where
 {
     type Expr;
 
-    fn new(input: Vec<Token>) -> Self;
+    // fn new(input: Vec<Token>) -> Self;
     fn input(&mut self) -> &mut PeekIter<Token>;
     fn parse(&mut self) -> T;
     fn parse_float(&mut self, f: f64, span: Span) -> Self::Expr;
@@ -110,6 +110,8 @@ where
         Self::Expr::bracket(inner, sp)
     }
     fn push_diag(&mut self, diagnostic: Diagnostic);
+
+    fn has_stmt_break(&mut self) -> bool;
 
     #[inline]
     fn done(&mut self) -> bool {
@@ -186,7 +188,7 @@ where
                 true
             }
             _ => false,
-        };
+        } && !self.has_stmt_break();
         if insert_synthetic_mult {
             let next_span = self.peek().span;
             let bw_cur_and_next = (tok_span.hi, next_span.lo);

--- a/libslide/src/parser/expression_pattern_parser.rs
+++ b/libslide/src/parser/expression_pattern_parser.rs
@@ -16,15 +16,17 @@ pub struct ExpressionPatternParser {
     diagnostics: Vec<Diagnostic>,
 }
 
-impl Parser<InternedExprPat> for ExpressionPatternParser {
-    type Expr = InternedExprPat;
-
+impl ExpressionPatternParser {
     fn new(input: Vec<Token>) -> Self {
         Self {
             _input: PeekIter::new(input.into_iter()),
             diagnostics: vec![],
         }
     }
+}
+
+impl Parser<InternedExprPat> for ExpressionPatternParser {
+    type Expr = InternedExprPat;
 
     fn input(&mut self) -> &mut PeekIter<Token> {
         &mut self._input
@@ -62,6 +64,10 @@ impl Parser<InternedExprPat> for ExpressionPatternParser {
 
     fn parse_any_pattern(&mut self, name: String, span: Span) -> Self::Expr {
         intern_expr_pat!(ExprPat::AnyPat(name), span)
+    }
+
+    fn has_stmt_break(&mut self) -> bool {
+        false
     }
 }
 

--- a/libslide/src/parser/statement_parser.rs
+++ b/libslide/src/parser/statement_parser.rs
@@ -6,41 +6,53 @@ use crate::scanner::types::{Token, TokenType};
 use crate::utils::{PeekIter, StringUtils};
 
 /// Parses a tokenized slide program, emitting the result and any diagnostics.
-pub fn parse(input: Vec<Token>) -> (Stmt, Vec<Diagnostic>) {
-    let mut parser = ExpressionParser::new(input);
+pub fn parse(input: Vec<Token>, program: &str) -> (StmtList, Vec<Diagnostic>) {
+    let mut parser = ExpressionParser::new(input, program);
     (parser.parse(), parser.diagnostics)
 }
 
-pub struct ExpressionParser {
+pub struct ExpressionParser<'a> {
     _input: PeekIter<Token>,
+    program: &'a str,
     diagnostics: Vec<Diagnostic>,
 }
 
-impl ExpressionParser {
+impl<'a> ExpressionParser<'a> {
+    fn new(input: Vec<Token>, program: &'a str) -> Self {
+        Self {
+            _input: PeekIter::new(input.into_iter()),
+            program,
+            diagnostics: vec![],
+        }
+    }
+
     fn assignment(&mut self, var: String) -> Stmt {
         Stmt::Assignment(Assignment {
             var,
             rhs: self.expr(),
         })
     }
-}
 
-impl ExpressionParser {
+    fn parse_stmt(&mut self) -> Stmt {
+        let mut next_2 = self.input().peek_map_n(2, |tok| tok.ty.clone());
+        match (next_2.pop_front(), next_2.pop_front()) {
+            (Some(TokenType::Variable(name)), Some(TokenType::Equal)) => {
+                self.input().next();
+                self.input().next();
+                self.assignment(name)
+            }
+            _ => Stmt::Expr(self.expr()),
+        }
+    }
+
     fn parse_pattern(&mut self, name: String, span: Span) -> InternedExpr {
         self.push_diag(IllegalPattern!(span, name));
         intern_expr!(Expr::Var(name), span)
     }
 }
 
-impl Parser<Stmt> for ExpressionParser {
+impl<'a> Parser<StmtList> for ExpressionParser<'a> {
     type Expr = InternedExpr;
-
-    fn new(input: Vec<Token>) -> Self {
-        Self {
-            _input: PeekIter::new(input.into_iter()),
-            diagnostics: vec![],
-        }
-    }
 
     fn input(&mut self) -> &mut PeekIter<Token> {
         &mut self._input
@@ -50,21 +62,22 @@ impl Parser<Stmt> for ExpressionParser {
         self.diagnostics.push(diagnostic);
     }
 
-    fn parse(&mut self) -> Stmt {
-        let mut next_2 = self.input().peek_map_n(2, |tok| tok.ty.clone());
-        let parsed = match (next_2.pop_front(), next_2.pop_front()) {
-            (Some(TokenType::Variable(name)), Some(TokenType::Equal)) => {
-                self.input().next();
-                self.input().next();
-                self.assignment(name)
+    fn parse(&mut self) -> StmtList {
+        let mut stmts = Vec::new();
+        while !self.done() {
+            stmts.push(self.parse_stmt());
+
+            if !self.done() && !self.has_stmt_break() {
+                let next_span = self.peek().span;
+                let extra_tokens_diag = extra_tokens_diag(self.input()).with_spanned_help(
+                    next_span,
+                    "if you meant to specify another statement, add a newline before this token",
+                );
+                self.push_diag(extra_tokens_diag);
+                break;
             }
-            _ => Stmt::Expr(self.expr()),
-        };
-        if !self.done() {
-            let extra_tokens_diag = extra_tokens_diag(self.input());
-            self.push_diag(extra_tokens_diag);
         }
-        parsed
+        StmtList::new(stmts)
     }
 
     fn parse_float(&mut self, f: f64, span: Span) -> Self::Expr {
@@ -85,6 +98,15 @@ impl Parser<Stmt> for ExpressionParser {
 
     fn parse_any_pattern(&mut self, name: String, span: Span) -> Self::Expr {
         self.parse_pattern(name, span)
+    }
+
+    /// Do we have another statement (on a newline)?
+    fn has_stmt_break(&mut self) -> bool {
+        self.peek()
+            .full_span
+            .clone()
+            .over(self.program)
+            .contains('\n')
     }
 }
 

--- a/libslide/src/partial_evaluator/flatten.rs
+++ b/libslide/src/partial_evaluator/flatten.rs
@@ -563,7 +563,8 @@ mod tests {
     fn flatten_cases() {
         for case in CASES {
             let mut split = case.split(" -> ");
-            let expr = parse_expr!(split.next().unwrap());
+            let lhs = split.next().unwrap();
+            let expr = parse_expr!(lhs);
             let expected_flattened = split.next().unwrap();
 
             let flattened = normalize(flatten_expr(expr)).emit_s_expression(Default::default());

--- a/libslide/src/utils/test.rs
+++ b/libslide/src/utils/test.rs
@@ -5,7 +5,7 @@ macro_rules! parse_stmt {
         use crate::{parse_statement, scan};
 
         let tokens = scan($expr).tokens;
-        let (parsed, _) = parse_statement(tokens);
+        let (parsed, _) = parse_statement(tokens, $expr);
         parsed
     }};
 }
@@ -15,7 +15,7 @@ macro_rules! parse_stmt {
 macro_rules! parse_expr {
     ($expr:expr) => {{
         use crate::grammar::*;
-        match crate::parse_stmt!($expr) {
+        match crate::parse_stmt!($expr).into_iter().next().unwrap() {
             Stmt::Expr(expr) => expr,
             _ => unreachable!(),
         }

--- a/slide/src/lib.rs
+++ b/slide/src/lib.rs
@@ -298,7 +298,7 @@ impl<'a> ProgramEvaluator<'a> {
 
     /// Handles evaluation of a regular slide program (statements, expressions).
     fn eval_slide_program(mut self) -> SlideResult {
-        let (parse_tree, diagnostics) = parse_statement(self.tokens);
+        let (parse_tree, diagnostics) = parse_statement(self.tokens, &self.result.org_program);
 
         self.result.err(&diagnostics);
         if !diagnostics.is_empty() {

--- a/slide/src/test/ui/extra_items.slide
+++ b/slide/src/test/ui/extra_items.slide
@@ -12,6 +12,7 @@ error[P0001]: Unexpected extra tokens
   |
 1 |   1 + 0 -1 2 3
   |  __________^
+  |            - help: if you meant to specify another statement, add a newline before this token
 2 | |   4 5 6 / 7 ^ 8
 3 | |   9 
   | |____^ not connected to a primary statement

--- a/slide/src/test/ui/multi_stmt/mixed_multi_stmt.slide
+++ b/slide/src/test/ui/multi_stmt/mixed_multi_stmt.slide
@@ -1,0 +1,26 @@
+@TODO: preserve newline between a = 250 and 7.25
+
+===in
+1 + 2 / 3 * 6
+a = 10 * 5 ^ 2
+
+10 / 8 + 1
++ 2 +
+3
+
+d = 1
+===in
+
+~~~stdout
+5
+a = 250
+7.25
+d = 1
+~~~stdout
+
+~~~stderr
+~~~stderr
+
+~~~exitcode
+0
+~~~exitcode

--- a/slide/src/test/ui/multi_stmt/multi_stmt_needs_newline.slide
+++ b/slide/src/test/ui/multi_stmt/multi_stmt_needs_newline.slide
@@ -1,0 +1,19 @@
+===in
+1 + 2 / 3 * 6 10 * 5 ^ 2
+===in
+
+~~~stdout
+~~~stdout
+
+~~~stderr
+error[P0001]: Unexpected extra tokens
+  |
+1 | 1 + 2 / 3 * 6 10 * 5 ^ 2 
+  |               ^^^^^^^^^^ not connected to a primary statement
+  |               -- help: if you meant to specify another statement, add a newline before this token
+  |
+~~~stderr
+
+~~~exitcode
+1
+~~~exitcode

--- a/slide/src/test/ui/tokens_past_expr.slide
+++ b/slide/src/test/ui/tokens_past_expr.slide
@@ -10,6 +10,7 @@ error[P0001]: Unexpected extra tokens
   |
 1 | 1 2 3 
   |   ^^^ not connected to a primary statement
+  |   - help: if you meant to specify another statement, add a newline before this token
   |
 ~~~stderr
 


### PR DESCRIPTION
This commit adds support for parsing and evaluating multiple statements
across lines. This means

```
1 + 2
a = 3
```

will be parsed as two statements correctly. However,

```
1 + 2 a = 3
```

will not, and neither will expression patterns.
