### PR TITLE
Expand variables in expressions with variable definitions

### DIFF
--- a/libslide/src/grammar/transformer.rs
+++ b/libslide/src/grammar/transformer.rs
@@ -1,7 +1,67 @@
-use super::Grammar;
+use super::*;
+use crate::Span;
 
 /// A trait for transforming one grammar into another.
 /// This transformer takes ownership of the grammar it transforms.
 pub trait Transformer<T: Grammar, U: Grammar> {
     fn transform(&self, item: T) -> U;
+}
+
+/// A trait for transforming one expression into another.
+pub trait ExpressionTransformer<'a> {
+    fn transform(&self, expr: &'a InternedExpr) -> InternedExpr {
+        match expr.as_ref() {
+            Expr::Const(k) => self.transform_const(k, expr.span),
+            Expr::Var(v) => self.transform_var(v, expr.span),
+            Expr::BinaryExpr(b) => self.transform_binary(b, expr.span),
+            Expr::UnaryExpr(u) => self.transform_unary(u, expr.span),
+            Expr::Parend(p) => self.transform_parend(p, expr.span),
+            Expr::Bracketed(b) => self.transform_bracketed(b, expr.span),
+        }
+    }
+
+    fn transform_const(&self, konst: &f64, span: Span) -> InternedExpr {
+        intern_expr!(Expr::Const(*konst), span)
+    }
+
+    fn transform_var(&self, var: &'a str, span: Span) -> InternedExpr {
+        intern_expr!(Expr::Var(var.to_owned()), span)
+    }
+
+    fn transform_binary_op(&self, op: BinaryOperator) -> BinaryOperator {
+        op
+    }
+
+    fn transform_binary(&self, expr: &'a BinaryExpr<InternedExpr>, span: Span) -> InternedExpr {
+        intern_expr!(
+            Expr::BinaryExpr(BinaryExpr {
+                op: self.transform_binary_op(expr.op),
+                lhs: self.transform(&expr.lhs),
+                rhs: self.transform(&expr.rhs),
+            }),
+            span
+        )
+    }
+
+    fn transform_unary_op(&self, op: UnaryOperator) -> UnaryOperator {
+        op
+    }
+
+    fn transform_unary(&self, expr: &'a UnaryExpr<InternedExpr>, span: Span) -> InternedExpr {
+        intern_expr!(
+            Expr::UnaryExpr(UnaryExpr {
+                op: self.transform_unary_op(expr.op),
+                rhs: self.transform(&expr.rhs),
+            }),
+            span
+        )
+    }
+
+    fn transform_parend(&self, expr: &'a InternedExpr, span: Span) -> InternedExpr {
+        intern_expr!(Expr::Parend(self.transform(expr)), span)
+    }
+
+    fn transform_bracketed(&self, expr: &'a InternedExpr, span: Span) -> InternedExpr {
+        intern_expr!(Expr::Bracketed(self.transform(expr)), span)
+    }
 }

--- a/libslide/src/partial_evaluator.rs
+++ b/libslide/src/partial_evaluator.rs
@@ -2,6 +2,7 @@
 
 pub mod flatten;
 mod types;
+mod variable_expand;
 use flatten::flatten_expr;
 pub use types::*;
 

--- a/libslide/src/partial_evaluator/variable_expand.rs
+++ b/libslide/src/partial_evaluator/variable_expand.rs
@@ -1,0 +1,147 @@
+//! This module expands variables in expressions to their definition form.
+
+#![allow(unused)] // TODO: remove
+
+use crate::grammar::*;
+use crate::Span;
+
+use std::collections::HashMap;
+
+trait VariableExpander<'a> {
+    /// Creates a new VariableExpander from an expression to expand.
+    fn new(expr: InternedExpr) -> Self;
+
+    /// Expands the variables matching the lhs of `asgn` with the assignment definition.
+    /// Consumes and returns self, providing a chaining API.
+    fn expand(self, asgn: &'a Assignment) -> Self;
+
+    /// Consumes `self` and returns the owned expression with any variables expanded.
+    fn finish(self) -> InternedExpr;
+}
+
+/// Eagerly expands variables in an expression.
+///
+/// An `EagerVariableExpander` expands all matching variables on every call to
+/// [`expand`](VariableExpander::expand).
+///
+/// For example, `"a + b".expand("a = b + 1").expand("b = c")` would expand to `"c + 1 + c"`.
+/// Compare this to a [`LazyVariableExpander`][LazyVariableExpander].
+///
+/// Note, however, that an `EagerVariableExpander` will not try to expand variables within an
+/// expanded variable definition on the same call to [`expand`](VariableExpander::expand).
+///
+/// For example, `"a".expand("a = a + a")` would expand to `"a + a"` rather than
+/// `"a + a + a + a + ..."`.
+struct EagerVariableExpander<'a> {
+    expr: InternedExpr,
+    expand_def: Option<&'a Assignment>,
+}
+
+impl<'a> ExpressionTransformer<'a> for EagerVariableExpander<'a> {
+    fn transform_var(&self, var: &'a str, span: Span) -> InternedExpr {
+        let asgn = self.expand_def.unwrap();
+        if var == asgn.var {
+            asgn.rhs
+        } else {
+            intern_expr!(Expr::Var(var.to_owned()), span)
+        }
+    }
+}
+
+impl<'a> VariableExpander<'a> for EagerVariableExpander<'a> {
+    fn new(expr: InternedExpr) -> Self {
+        Self {
+            expr,
+            expand_def: None,
+        }
+    }
+
+    fn expand(mut self, asgn: &'a Assignment) -> Self {
+        self.expand_def = Some(asgn);
+        self.expr = self.transform(&self.expr);
+        self
+    }
+
+    fn finish(self) -> InternedExpr {
+        self.expr
+    }
+}
+
+/// Lazily expands variables in an expression.
+///
+/// A `LazyVariableExpander` expands each variable exactly once, when
+/// [`finish`](VariableExpander::finish) is called, and does not expand variables within an expanded
+/// variable definition.
+///
+/// For example, `"a + b".expand("a = b + 1").expand("b = c")` would expand to `"b + 1 + c"`.
+/// Compare this to an [`EagerVariableExpander`][EagerVariableExpander].
+///
+/// Furthermore, the variable definition used by a `LazyVariableExpander` is the last one given via
+/// [`expand`](VariableExpander::expand).
+///
+/// For example, `"a + a".expand("a = 1").expand("a = 10")` would expand to `"10 + 10"`.
+struct LazyVariableExpander<'a> {
+    expr: InternedExpr,
+    expand_defs: HashMap<&'a str, &'a InternedExpr>,
+}
+
+impl<'a> ExpressionTransformer<'a> for LazyVariableExpander<'a> {
+    fn transform_var(&self, var: &'a str, span: Span) -> InternedExpr {
+        match self.expand_defs.get(var) {
+            Some(def) => **def,
+            None => intern_expr!(Expr::Var(var.to_owned()), span),
+        }
+    }
+}
+
+impl<'a> VariableExpander<'a> for LazyVariableExpander<'a> {
+    fn new(expr: InternedExpr) -> Self {
+        Self {
+            expr,
+            expand_defs: HashMap::new(),
+        }
+    }
+
+    fn expand(mut self, asgn: &'a Assignment) -> Self {
+        self.expand_defs.insert(&asgn.var, &asgn.rhs);
+        self
+    }
+
+    fn finish(self) -> InternedExpr {
+        self.transform(&self.expr)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::{EagerVariableExpander, LazyVariableExpander, VariableExpander};
+    use crate::{parse_asgn, parse_expr};
+
+    #[test]
+    fn eager_variable_expander() {
+        let expr = parse_expr!("a + b + a + 1 / 2");
+        let a = parse_asgn!("a = b / 5");
+        let b = parse_asgn!("b = c");
+
+        let expanded = EagerVariableExpander::new(expr)
+            .expand(&a)
+            .expand(&b)
+            .finish();
+
+        assert_eq!(expanded.to_string(), "c / 5 + c + c / 5 + 1 / 2");
+    }
+
+    #[test]
+    fn lazy_variable_expander() {
+        let expr = parse_expr!("a + b + a + 1 / 2");
+        let a = parse_asgn!("a = b / 5");
+        let b = parse_asgn!("b = c");
+
+        let expanded = LazyVariableExpander::new(expr)
+            .expand(&a)
+            .expand(&b)
+            .finish();
+
+        assert_eq!(expanded.to_string(), "b / 5 + c + b / 5 + 1 / 2");
+    }
+}

--- a/libslide/src/utils/test.rs
+++ b/libslide/src/utils/test.rs
@@ -21,3 +21,15 @@ macro_rules! parse_expr {
         }
     }};
 }
+
+/// Parses an assignment.
+#[macro_export]
+macro_rules! parse_asgn {
+    ($asgn:expr) => {{
+        use crate::grammar::*;
+        match crate::parse_stmt!($asgn).into_iter().next().unwrap() {
+            Stmt::Assignment(asgn) => asgn,
+            _ => unreachable!(),
+        }
+    }};
+}


### PR DESCRIPTION
This prepares for a component in the partial evalautor that will
substitute terminated (or nearly-terminated) variable definitions in
expressions using those variables to simplify the expression further.
For example, if we have

```
b = 1 + a + 2 + a
a = 3
```

we currently reduce this to

```
b = 3 + 2a
a = 3
```

but of course we might want to do

```
b = 9
a = 3
```

Closes #243
