### PR TITLE
Emit assignment op in original form

### DIFF
--- a/slide/src/lib.rs
+++ b/slide/src/lib.rs
@@ -92,13 +92,12 @@ where
                     \tfrac          (latex):        Emit divisions as fractions.\n\
                     \ttimes         (latex):        Emit \"\\times\" for multiplications.\n\
                     \tdiv           (latex):        Emit \"\\div\" for divisions.\n\
-                    \tdefine-assign (pretty|latex): Use \":=\" for assignments.\n\
                     \timplicit-mult (pretty|latex): Use implicit multiplication where possible.\n\
                     ",
                 )
                 .hide_possible_values(true)
                 .takes_value(true)
-                .possible_values(&["frac", "times", "div", "define-assign", "implicit-mult"])
+                .possible_values(&["frac", "times", "div", "implicit-mult"])
                 .multiple(true),
         )
         .arg(

--- a/slide/src/test/ui/cli/help.slide
+++ b/slide/src/test/ui/cli/help.slide
@@ -26,7 +26,6 @@ OPTIONS:
             	frac          (latex):        Emit divisions as fractions.
             	times         (latex):        Emit "\times" for multiplications.
             	div           (latex):        Emit "\div" for divisions.
-            	define-assign (pretty|latex): Use ":=" for assignments.
             	implicit-mult (pretty|latex): Use implicit multiplication where possible.
         --explain <diagnostic>            Provide a detailed explanation for a diagnostic code.
     -o, --output-form <output-form>

--- a/slide/src/test/ui/emit/pretty/define-assign.slide
+++ b/slide/src/test/ui/emit/pretty/define-assign.slide
@@ -1,7 +1,3 @@
-!!!args
---emit-config=define-assign
-!!!args
-
 ===in
 A := 5
 ===in

--- a/slide/src/test/ui/lint/homogenous_assignment_assign_define.slide
+++ b/slide/src/test/ui/lint/homogenous_assignment_assign_define.slide
@@ -11,10 +11,10 @@ e = 5
 ===in
 
 ~~~stdout
-a = 1
+a := 1
 b = 2
 c = 3
-d = 4
+d := 4
 e = 5
 ~~~stdout
 

--- a/slide/src/test/ui/lint/homogenous_assignment_equal.slide
+++ b/slide/src/test/ui/lint/homogenous_assignment_equal.slide
@@ -12,10 +12,10 @@ e := 5
 
 ~~~stdout
 a = 1
-b = 2
-c = 3
+b := 2
+c := 3
 d = 4
-e = 5
+e := 5
 ~~~stdout
 
 ~~~stderr

--- a/www/index.html
+++ b/www/index.html
@@ -210,7 +210,6 @@
         frac: false,
         times: false,
         div: false,
-        "define-assign": false,
         "implicit-mult": false,
       };
       const BASE_ISSUE_URL = "https://github.com/yslide/slide/issues/new";


### PR DESCRIPTION
Previously we would always emit assignment operators as = or :=,
depending on the emit config options. But now we have parse information
about the assignment op, so just use that.

ptal @lukebhan
