### PR TITLE
Add validation errors for assignments with incompatible definitions

### DIFF
--- a/libslide/src/diagnostics.rs
+++ b/libslide/src/diagnostics.rs
@@ -8,7 +8,7 @@
 //! - easily transformable into some output form by downstream customers (namely the slide app)
 
 use crate::common::Span;
-use crate::{LintConfig, ParseErrors, ScanErrors};
+use crate::{LintConfig, ParseErrors, PartialEvaluatorErrors, ScanErrors};
 
 use std::collections::HashMap;
 
@@ -148,6 +148,8 @@ impl Diagnostic {
     }
 
     with_spanned_diag! {
+        /// Adds an error to the diagnostic, possibly at a different span.
+        with_spanned_err as Error
         /// Adds a help message to the diagnostic, possibly at a different span.
         with_spanned_help as Help
         /// Adds a note to the diagnostic, possibly at a different span.
@@ -187,7 +189,7 @@ macro_rules! include_diagnostic_registries {
                     assert_eq!(code.len(), 5);
                     assert!(matches!(
                         code.chars().next(),
-                        Some('L') | Some('S') | Some('P')
+                        Some('L') | Some('S') | Some('P') | Some('V')
                     ));
                     for ch in code.chars().skip(1) {
                         assert!(matches!(ch, '0'..='9'));
@@ -202,4 +204,5 @@ include_diagnostic_registries! {
     LintConfig
     ParseErrors
     ScanErrors
+    PartialEvaluatorErrors
 }

--- a/libslide/src/emit.rs
+++ b/libslide/src/emit.rs
@@ -206,11 +206,9 @@ impl Emit for Stmt {
     fn emit_s_expression(&self, config: EmitConfig) -> String {
         match self {
             Self::Expr(expr) => expr.emit_s_expression(config),
-            Self::Assignment(Assignment {
-                var,
-                rhs,
-                asgn_op: _,
-            }) => format!("(= {} {})", var, rhs.emit_s_expression(config)),
+            Self::Assignment(Assignment { var, rhs, .. }) => {
+                format!("(= {} {})", var, rhs.emit_s_expression(config))
+            }
         }
     }
 

--- a/libslide/src/evaluator_rules/mod.rs
+++ b/libslide/src/evaluator_rules/mod.rs
@@ -8,6 +8,7 @@ mod registry;
 mod rule;
 mod unbuilt_rule;
 
+pub use registry::BuildRuleErrors;
 pub use registry::RuleName;
 pub use registry::RuleSet;
 pub use rule::Rule;

--- a/libslide/src/grammar.rs
+++ b/libslide/src/grammar.rs
@@ -95,6 +95,7 @@ where
     E: RcExpression,
 {
     mkop! {
+        sub: BinaryOperator::Minus
         mult: BinaryOperator::Mult
         div:  BinaryOperator::Div
         exp:  BinaryOperator::Exp

--- a/libslide/src/grammar/statement.rs
+++ b/libslide/src/grammar/statement.rs
@@ -101,6 +101,7 @@ pub struct Assignment {
     pub var: InternedStr,
     pub asgn_op: AssignmentOp,
     pub rhs: RcExpr,
+    pub span: Span,
 }
 
 #[derive(Clone, PartialEq, Debug)]

--- a/libslide/src/lib.rs
+++ b/libslide/src/lib.rs
@@ -227,6 +227,7 @@ pub(crate) use linter::LintConfig;
 mod partial_evaluator;
 pub use partial_evaluator::evaluate;
 pub use partial_evaluator::EvaluatorContext;
+pub(crate) use partial_evaluator::PartialEvaluatorErrors;
 
 mod evaluator_rules;
 

--- a/libslide/src/partial_evaluator/errors.rs
+++ b/libslide/src/partial_evaluator/errors.rs
@@ -1,0 +1,78 @@
+//! Diagnostic errors produced by the partial evaluator.
+
+use crate::diagnostics::{DiagnosticRecord, DiagnosticRegistry};
+
+macro_rules! define_errors {
+    ($($(#[doc = $doc:expr])+ $code:ident: $error:ident $gen_macro:tt)*) => {$(
+        $(#[doc = $doc])+
+        pub(crate) struct $error;
+
+        impl DiagnosticRecord for $error {
+            const CODE: &'static str = stringify!($code);
+            const EXPLANATION: &'static str = concat!($($doc, "\n"),+);
+        })*
+
+        pub struct PartialEvaluatorErrors;
+
+        impl DiagnosticRegistry for PartialEvaluatorErrors {
+            fn codes_with_explanations() -> Vec<(&'static str, &'static str)> {
+                let mut vec = Vec::new();
+                $(vec.push(($error::CODE, $error::EXPLANATION));)*
+                vec
+            }
+        }
+
+        $(
+            macro_rules! $error $gen_macro
+        )*
+    };
+}
+
+define_errors! {
+    ///This error is fired on variable definitions provided to a slide program that can never be
+    ///compatible. For example, given the program
+    ///
+    ///```text
+    ///a := 1
+    ///a := 12 - 10
+    ///```
+    ///
+    ///"a" is defined as "1" and "2" simultaneously, which are incompatible definitions.
+    ///
+    ///This error is only fired when slide is able to statically detect incompatibility of
+    ///defintions. For example, without having information on what "c" is defined as, the program
+    ///
+    ///```text
+    ///a := c
+    ///a := 2c
+    ///```
+    ///
+    ///would not have an incompatible definitions error, because the program is valid when "c = 0".
+    ///However, if slide knew about that value of "c", as it would in the program
+    ///
+    ///```text
+    ///a := c
+    ///a := 2c
+    ///c := 1
+    ///```
+    ///
+    ///an incompatible definitions error could now be fired on the two definitions of "a".
+    V0001: IncompatibleDefinitions {
+        ($var:expr, $a_def:expr, $b_def:expr) => {
+            Diagnostic::span_err(
+                $a_def.span,
+                format!(r#"Definitions of "{}" are incompatible"#, $var),
+                "V0001",
+                format!(r#"this definition evaluates to "{}""#, $a_def),
+            )
+            .with_spanned_err(
+                $b_def.span,
+                format!(r#"this definition evaluates to "{}""#, $b_def),
+            )
+            .with_note(format!(
+                r#""{}" and "{}" are never equal"#,
+                $a_def.rhs, $b_def.rhs
+            ))
+        }
+    }
+}

--- a/libslide/src/partial_evaluator/validate/incompatible_definitions.rs
+++ b/libslide/src/partial_evaluator/validate/incompatible_definitions.rs
@@ -1,0 +1,94 @@
+//! Detects incompatible variable definitions in a slide program.
+//!
+//! See the [`IncompatibleDefinitions`](crate::partial_evaluator::errors::IncompatibleDefinitions)
+//! error for more details.
+
+use super::Validator;
+
+use crate::diagnostics::Diagnostic;
+use crate::evaluator_rules::Rule;
+use crate::grammar::*;
+use crate::partial_evaluator::{evaluate_expr, EvaluatorContext};
+
+use std::collections::HashMap;
+
+/// Max number of definition pairs we generate diagnostics for.
+///
+/// We set a hard bound on this because generating information for a tremendous amount of
+/// incompatible definitions is not very useful to a user, and is very costly because the partial
+/// evaluator is run over each definition pair.
+static MAX_DEFINITION_PAIRS: usize = 100;
+
+#[derive(Default)]
+pub(super) struct IncompatibleDefinitionsValidator<'a> {
+    asgns: HashMap<InternedStr, Vec<&'a Assignment>>,
+}
+
+impl<'a> IncompatibleDefinitionsValidator<'a> {
+    fn all_ordered_definition_pairs(self) -> Vec<(&'a Assignment, &'a Assignment)> {
+        let mut definition_pairs = Vec::new();
+        for (_name, asgns) in self.asgns.into_iter() {
+            if asgns.len() < 2 {
+                continue;
+            }
+            if definition_pairs.len() > MAX_DEFINITION_PAIRS {
+                break;
+            }
+            let mut pairs = Vec::with_capacity((asgns.len() * asgns.len() - 1) / 2);
+            for i in 0..asgns.len() {
+                for j in i + 1..asgns.len() {
+                    pairs.push((asgns[i], asgns[j]));
+                }
+            }
+            definition_pairs.extend(pairs);
+        }
+        while definition_pairs.len() > MAX_DEFINITION_PAIRS {
+            definition_pairs.pop();
+        }
+        definition_pairs.sort_by(|&(a, c), &(b, d)| {
+            if a.span == b.span {
+                c.span.cmp(&d.span)
+            } else {
+                a.span.cmp(&b.span)
+            }
+        });
+        definition_pairs
+    }
+
+    fn validate(self, context: &EvaluatorContext, evaluator_rules: &[Rule]) -> Vec<Diagnostic> {
+        let mut diagnostics = Vec::new();
+        let definition_pairs = self.all_ordered_definition_pairs();
+        for (def_a, def_b) in definition_pairs.into_iter() {
+            let diff = rc_expr!(
+                Expr::BinaryExpr(BinaryExpr::sub(def_a.rhs.clone(), def_b.rhs.clone())),
+                crate::DUMMY_SP
+            );
+            let diff = evaluate_expr(diff, evaluator_rules, context);
+            match diff.get_const() {
+                None => continue,
+                Some(e) if e.abs() <= std::f64::EPSILON => continue,
+                Some(_) => diagnostics.push(IncompatibleDefinitions!(def_a.var, def_a, def_b)),
+            }
+        }
+        diagnostics
+    }
+}
+
+impl<'a> StmtVisitor<'a> for IncompatibleDefinitionsValidator<'a> {
+    fn visit_asgn(&mut self, asgn: &'a Assignment) {
+        self.asgns.entry(asgn.var).or_default().push(asgn);
+    }
+}
+
+impl<'a> Validator<'a> for IncompatibleDefinitionsValidator<'a> {
+    fn validate(
+        stmt_list: &StmtList,
+        _source: &'a str,
+        context: &EvaluatorContext,
+        evaluator_rules: &[Rule],
+    ) -> Vec<Diagnostic> {
+        let mut validator = IncompatibleDefinitionsValidator::default();
+        validator.visit(stmt_list);
+        validator.validate(context, evaluator_rules)
+    }
+}

--- a/libslide/src/partial_evaluator/validate/mod.rs
+++ b/libslide/src/partial_evaluator/validate/mod.rs
@@ -1,0 +1,59 @@
+//! Validates that evaluated slide programs are well-formed. In some sense, validations are
+//! post-evaluator linters.
+
+mod incompatible_definitions;
+use incompatible_definitions::*;
+
+use super::EvaluatorContext;
+
+use crate::diagnostics::Diagnostic;
+use crate::evaluator_rules::Rule;
+use crate::grammar::StmtList;
+
+trait Validator<'a> {
+    fn validate(
+        stmt_list: &StmtList,
+        source: &'a str,
+        context: &EvaluatorContext,
+        evaluator_rules: &[Rule],
+    ) -> Vec<Diagnostic>;
+}
+
+macro_rules! register_validators {
+    ($($validator:ident,)*) => {
+        enum PEValidator {
+            $($validator),*
+        }
+
+        impl PEValidator {
+            fn validate<'a>(
+                &self,
+                stmt_list: &StmtList,
+                source: &'a str,
+                context: &EvaluatorContext,
+                evaluator_rules: &[Rule],
+            ) -> Vec<Diagnostic> {
+                match self {
+                    $(Self::$validator => $validator::validate(
+                            stmt_list, source, context, evaluator_rules)),*
+                }
+            }
+        }
+
+        pub(super) fn validate<'a>(
+            stmt_list: &StmtList,
+            source: &'a str,
+            context: &EvaluatorContext,
+            evaluator_rules: &[Rule],
+        ) -> Vec<Diagnostic> {
+            [$(PEValidator::$validator),*]
+                .iter()
+                .flat_map(|v| v.validate(stmt_list, source, context, evaluator_rules))
+                .collect()
+        }
+    }
+}
+
+register_validators! {
+    IncompatibleDefinitionsValidator,
+}

--- a/libslide/src/scanner.rs
+++ b/libslide/src/scanner.rs
@@ -140,7 +140,7 @@ impl Scanner {
             ']' => CloseBracket,
             c => Invalid(c.to_string()),
         };
-        let span = span.unwrap_or_else(|| start..self.pos);
+        let span = span.unwrap_or(start..self.pos);
 
         if matches!(ty, Invalid(..)) {
             self.push_diag(InvalidToken!(span.clone(), did_you_mean));

--- a/slide/src/lib.rs
+++ b/slide/src/lib.rs
@@ -314,12 +314,21 @@ impl<'a> ProgramEvaluator<'a> {
 
         if self.parse_only {
             self.result.emit(&parse_tree);
-        } else {
-            let simplified = evaluate(parse_tree, &EvaluatorContext::default()).unwrap();
-            self.result.emit(&simplified);
-        }
 
-        self.result.ok()
+            self.result.ok()
+        } else {
+            let (simplified, diagnostics) =
+                evaluate(parse_tree, &EvaluatorContext::default()).unwrap();
+
+            self.result.err(&diagnostics);
+            self.result.emit(&simplified);
+
+            if diagnostics.is_empty() {
+                self.result.ok()
+            } else {
+                self.result.failed()
+            }
+        }
     }
 
     /// Handles evaluation of a slide expression pattern.

--- a/slide/src/test/ui/error/codes/V0001.slide
+++ b/slide/src/test/ui/error/codes/V0001.slide
@@ -1,0 +1,44 @@
+!!!args
+--explain=V0001
+!!!args
+
+===in
+===in
+
+~~~stdout
+This error is fired on variable definitions provided to a slide program that can never be
+compatible. For example, given the program
+
+```text
+a := 1
+a := 12 - 10
+```
+
+"a" is defined as "1" and "2" simultaneously, which are incompatible definitions.
+
+This error is only fired when slide is able to statically detect incompatibility of
+defintions. For example, without having information on what "c" is defined as, the program
+
+```text
+a := c
+a := 2c
+```
+
+would not have an incompatible definitions error, because the program is valid when "c = 0".
+However, if slide knew about that value of "c", as it would in the program
+
+```text
+a := c
+a := 2c
+c := 1
+```
+
+an incompatible definitions error could now be fired on the two definitions of "a".
+~~~stdout
+
+~~~stderr
+~~~stderr
+
+~~~exitcode
+0
+~~~exitcode

--- a/slide/src/test/ui/error/validate/incompatible_definitions.slide
+++ b/slide/src/test/ui/error/validate/incompatible_definitions.slide
@@ -1,0 +1,91 @@
+===in
+a := 1
+b = 2
+a := 3 ^ 5
+b = 4 - 2
+a := (v - v) * 2
+b = v + v - (2v + 1)
+
+c = v
+c = v + 1
+===in
+
+~~~stdout
+a := 1
+b = 2
+a := 243
+b = 2
+a := 0
+b = -1
+c = v
+c = v + 1
+~~~stdout
+
+~~~stderr
+error[V0001]: Definitions of "a" are incompatible
+  |
+1 | a := 1
+  | ^^^^^^ this definition evaluates to "a := 1"
+2 | b = 2
+3 | a := 3 ^ 5
+  | ^^^^^^^^^^ this definition evaluates to "a := 243"
+  |
+  = note: "1" and "243" are never equal
+
+error[V0001]: Definitions of "a" are incompatible
+  |
+1 | a := 1
+  | ^^^^^^ this definition evaluates to "a := 1"
+...
+5 | a := (v - v) * 2
+  | ^^^^^^^^^^^^^^^^ this definition evaluates to "a := 0"
+  |
+  = note: "1" and "0" are never equal
+
+error[V0001]: Definitions of "b" are incompatible
+  |
+1 | a := 1
+2 | b = 2
+  | ^^^^^ this definition evaluates to "b = 2"
+...
+6 | b = v + v - (2v + 1)
+  | ^^^^^^^^^^^^^^^^^^^^ this definition evaluates to "b = -1"
+  |
+  = note: "2" and "-1" are never equal
+
+error[V0001]: Definitions of "a" are incompatible
+  |
+...
+3 | a := 3 ^ 5
+  | ^^^^^^^^^^ this definition evaluates to "a := 243"
+4 | b = 4 - 2
+5 | a := (v - v) * 2
+  | ^^^^^^^^^^^^^^^^ this definition evaluates to "a := 0"
+  |
+  = note: "243" and "0" are never equal
+
+error[V0001]: Definitions of "b" are incompatible
+  |
+...
+4 | b = 4 - 2
+  | ^^^^^^^^^ this definition evaluates to "b = 2"
+5 | a := (v - v) * 2
+6 | b = v + v - (2v + 1)
+  | ^^^^^^^^^^^^^^^^^^^^ this definition evaluates to "b = -1"
+  |
+  = note: "2" and "-1" are never equal
+
+error[V0001]: Definitions of "c" are incompatible
+  |
+...
+8 | c = v
+  | ^^^^^ this definition evaluates to "c = v"
+9 | c = v + 1 
+  | ^^^^^^^^^ this definition evaluates to "c = v + 1"
+  |
+  = note: "v" and "v + 1" are never equal
+~~~stderr
+
+~~~exitcode
+1
+~~~exitcode


### PR DESCRIPTION
See the tests and partial_evaluator/validate/incompatible_definitions.rs
for more details. Synopsis from the error message:

This error is fired on variable definitions provided to a slide program that can never be
compatible. For example, given the program

```text
a := 1
a := 12 - 10
```

"a" is defined as "1" and "2" simultaneously, which are incompatible definitions.

This error is only fired when slide is able to statically detect incompatibility of
defintions. For example, without having information on what "c" is defined as, the program

```text
a := c
a := 2c
```

would not have an incompatible definitions error, because the program is valid when "c = 0".
However, if slide knew about that value of "c", as it would in the program

```text
a := c
a := 2c
c := 1
```

an incompatible definitions error could now be fired on the two definitions of "a".

ptal @lukebhan
