### PR TITLE
Make latex emit test optional locally, pool requests, use mathjax on UI

### DIFF
--- a/ladder
+++ b/ladder
@@ -16,6 +16,7 @@ DEFAULTS = SimpleNamespace(
     jobs=8,
     bless=False,
     fail_todo=False,
+    no_latex=False,
     open=False,
 )
 
@@ -75,6 +76,8 @@ def test(args, runner_args):
         env["BLESS"] = "1"
     if args.fail_todo:
         env["FAIL_TODO"] = "1"
+    if args.no_latex:
+        env["NO_LATEX"] = "1"
 
     process = subprocess.run(cargo_args, env=env)
     return process.returncode
@@ -194,6 +197,13 @@ test_parser.add_argument(
     action="store_true",
     default=DEFAULTS.bless,
     help="""Fail on tests with a @TODO annotation.
+This only affects system tests."""
+)
+test_parser.add_argument(
+    "--no-latex",
+    action="store_true",
+    default=DEFAULTS.no_latex,
+    help="""Do not run LaTeX emit tests. This may speed up local execution.
 This only affects system tests."""
 )
 test_parser.set_defaults(handler=test)

--- a/slide/src/test/common.rs
+++ b/slide/src/test/common.rs
@@ -11,6 +11,7 @@ lazy_static! {
         RwLock::new(HashMap::new());
     pub static ref BLESS: bool = std::env::var("BLESS") == Ok("1".into());
     pub static ref FAIL_TODO: bool = std::env::var("FAIL_TODO") == Ok("1".into());
+    pub static ref TEST_LATEX_EMIT: bool = std::env::var("NO_LATEX") != Ok("1".into());
 }
 
 macro_rules! prefix_severity {

--- a/slide/src/test/latex_emit_test.rs
+++ b/slide/src/test/latex_emit_test.rs
@@ -1,5 +1,12 @@
 use super::*;
 
+use lazy_static::lazy_static;
+use reqwest::blocking::Client;
+
+lazy_static! {
+    pub static ref CLIENT: Client = Client::new();
+}
+
 #[derive(Clone)]
 pub struct LaTeXEmitTest {
     /// Annotation name -> Annotation message
@@ -28,12 +35,10 @@ impl LaTeXEmitTest {
             math_mode_inner
         );
 
-        // TODO: pool connections
-        let mb_img_bytes = reqwest::blocking::get(
-            reqwest::Url::parse(&latex_img_url)
-                .unwrap_or_else(|_| panic!("LaTeX image url is invalid: {}", latex_img_url)),
-        )
-        .and_then(|resp| resp.bytes());
+        let mb_img_bytes = CLIENT
+            .get(&latex_img_url)
+            .send()
+            .and_then(|resp| resp.bytes());
         let img_bytes = match mb_img_bytes {
             Ok(bytes) => bytes,
             Err(err) => {

--- a/slide/src/test/mod.rs
+++ b/slide/src/test/mod.rs
@@ -93,7 +93,8 @@ impl TestCase {
             }
         };
 
-        if (slide_emit_test.args.contains(" latex") || slide_emit_test.args.contains("=latex"))
+        if *TEST_LATEX_EMIT
+            && (slide_emit_test.args.contains(" latex") || slide_emit_test.args.contains("=latex"))
             && slide_emit_test.exitcode.trim() == "0"
         {
             // The check could be better, but this will do for now.

--- a/www/index.html
+++ b/www/index.html
@@ -78,6 +78,22 @@
       crossorigin="anonymous"
     ></script>
     <script src="https://cdn.jsdelivr.net/npm/ansi_up@4.0.4/ansi_up.min.js"></script>
+
+    <script>
+      MathJax = {
+        tex: {
+          inlineMath: [["$", "$"]],
+        },
+        svg: {
+          fontCache: "global",
+        },
+      };
+    </script>
+    <script
+      src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/3.1.2/es5/tex-chtml.min.js"
+      integrity="sha512-OEN4O//oR+jeez1OLySjg7HPftdoSaKHiWukJdbFJOfi2b7W0r0ppziSgVRVNaG37qS1f9SmttcutYgoJ6rwNQ=="
+      crossorigin="anonymous"
+    ></script>
   </head>
   <body>
     <div class="d-flex flex-column flex-row flex-items-center">
@@ -180,14 +196,7 @@
         <button type="submit" class="btn btn-md btn-primary" v-on:click="runSlide">slide!</button>
 
         <h2>Output</h2>
-        <div class="ml-3 mr-3">
-          <img
-            v-bind:src="latexEmitImgUrl"
-            alt="Latex emit"
-            v-show="showLatexEmitImg"
-            class="mb-2"
-          />
-        </div>
+        <div class="ml-3 mr-3 mb-2" v-show="showLatexEmit" :key="output">{{kutput}}</div>
         <pre id="slide-output"><component :is="outputComponent" /></pre>
         <a v-bind:href="bugReportUrl" v-if="ranOnce">Report a bug</a>
       </article>
@@ -252,8 +261,7 @@
           explain,
           bugReportUrl: BASE_ISSUE_URL,
           ranOnce: false,
-          latexEmitImgUrl: "",
-          showLatexEmitImg: false,
+          showLatexEmit: false,
         },
         computed: {
           commitUrl() {
@@ -289,6 +297,9 @@
         },
         updated() {
           this.updateUrl();
+          if (this.showLatexEmit) {
+            MathJax.typeset();
+          }
         },
         methods: {
           updateUrl() {
@@ -336,10 +347,10 @@
                 /(error|warning)\[([LSPV]\d+)\]/g,
                 '$1[<a href="#slide-output" v-on:click="explain(\'$2\')">$2</a>]'
               );
+            this.showLatexEmit = code === 0 && this.emitFormat === "latex";
             this.ranOnce = true;
             this.updateUrl();
             this.updateBugReportUrl(slideOpts);
-            this.updateLatexEmitImg(code);
           },
 
           updateBugReportUrl(slideOpts) {
@@ -386,16 +397,6 @@ on commit ${this.commit}.
             const queryParams = new URLSearchParams();
             queryParams.set("body", body);
             this.bugReportUrl = `${BASE_ISSUE_URL}?${queryParams}`;
-          },
-
-          updateLatexEmitImg(code) {
-            this.showLatexEmitImg = code === 0 && this.emitFormat === "latex";
-            if (this.showLatexEmitImg) {
-              // slice(1, -1) to strip inline math mode: $<expr>$
-              const math = this.output.startsWith("$") ? this.output.slice(1, -1) : this.output;
-              const latex = encodeURIComponent(math);
-              this.latexEmitImgUrl = `https://latex.codecogs.com/svg.latex?${latex}`;
-            }
           },
         },
       });


### PR DESCRIPTION
Turns out calls to the web API are actually faster than MathJax->png,
but we can speed up tests locally by making latex emit tests optional or
pooling requests to the web API. Furthermore, use MathJax on the web UI
to make it faster there.

Closes #273
