### PR TITLE
Support autofixes on diagnostics

### DIFF
--- a/editor/language_server/src/tests/diagnostics.rs
+++ b/editor/language_server/src/tests/diagnostics.rs
@@ -71,7 +71,6 @@ async fn open_and_change_with_diagnostics() {
             text,
             "/", [Error P0002] "Expected an expression, found / \\ expected an expression";; vec![],
             "++5", [Warning L0002] "Trivially reducible unary operator chain";; related_info! { text,
-                file@"++5", "consider reducing this expression to \"5\""
             }
         }
     );
@@ -90,7 +89,6 @@ async fn open_and_change_with_diagnostics() {
         diagnostics! {
             text,
             "++5", [Warning L0002] "Trivially reducible unary operator chain";; related_info! { text,
-                file@"++5", "consider reducing this expression to \"5\""
             }
         }
     );

--- a/libslide/src/linter/stmt/redundant_nesting.rs
+++ b/libslide/src/linter/stmt/redundant_nesting.rs
@@ -18,7 +18,7 @@ explain_lint! {
 use crate::linter::LintRule;
 
 use crate::common::Span;
-use crate::diagnostics::Diagnostic;
+use crate::diagnostics::{Autofix, Diagnostic, Edit};
 use crate::grammar::visit::StmtVisitor;
 use crate::grammar::*;
 
@@ -50,10 +50,10 @@ impl<'a> RedundantNestingLinter<'a> {
             let inner_expr = expr.span.over(self.source);
 
             self.diagnostics.push(
-                Diagnostic::span_warn(span, "Redundant nesting", Self::CODE, None).with_help(
-                    format!(
-                        r#"consider reducing this expression to "{}{}{}""#,
-                        opener, inner_expr, closer
+                Diagnostic::span_warn(span, "Redundant nesting", Self::CODE, None).with_autofix(
+                    Autofix::for_sure(
+                        "reduce this nesting",
+                        Edit::Replace(format!("{}{}{}", opener, inner_expr, closer)),
                     ),
                 ),
             )

--- a/libslide/src/linter/stmt/unary_series.rs
+++ b/libslide/src/linter/stmt/unary_series.rs
@@ -18,7 +18,7 @@ explain_lint! {
 use crate::linter::LintRule;
 
 use crate::common::Span;
-use crate::diagnostics::Diagnostic;
+use crate::diagnostics::{Autofix, Diagnostic, Edit};
 use crate::grammar::visit::StmtVisitor;
 use crate::grammar::*;
 
@@ -61,9 +61,9 @@ impl<'a> StmtVisitor<'a> for UnarySeriesLinter<'a> {
                     Self::CODE,
                     None,
                 )
-                .with_help(format!(
-                    r#"consider reducing this expression to "{}""#,
-                    reduced_expr
+                .with_autofix(Autofix::for_sure(
+                    "reduce this expression",
+                    Edit::Replace(reduced_expr),
                 )),
             )
         }

--- a/libslide/src/parser/expression_pattern_parser.rs
+++ b/libslide/src/parser/expression_pattern_parser.rs
@@ -1,6 +1,6 @@
 use super::{errors::*, ParseResult, Parser};
 use crate::common::Span;
-use crate::diagnostics::{Diagnostic, DiagnosticRecord};
+use crate::diagnostics::Diagnostic;
 use crate::grammar::*;
 use crate::scanner::types::Token;
 use crate::utils::PeekIter;

--- a/libslide/src/parser/statement_parser.rs
+++ b/libslide/src/parser/statement_parser.rs
@@ -1,6 +1,6 @@
 use super::{errors::*, ParseResult, Parser};
 use crate::common::Span;
-use crate::diagnostics::{Diagnostic, DiagnosticRecord};
+use crate::diagnostics::Diagnostic;
 use crate::grammar::*;
 use crate::scanner::types::{Token, TokenType};
 use crate::utils::{PeekIter, StringUtils};

--- a/libslide/src/scanner.rs
+++ b/libslide/src/scanner.rs
@@ -10,7 +10,7 @@ use types::TokenType as TT;
 pub use types::*;
 
 use crate::common::Span;
-use crate::diagnostics::{Diagnostic, DiagnosticRecord};
+use crate::diagnostics::Diagnostic;
 use strtod::strtod;
 
 /// Describes the result of tokenizing a slide program.

--- a/libslide/src/scanner/errors.rs
+++ b/libslide/src/scanner/errors.rs
@@ -46,6 +46,8 @@ define_errors! {
     ///what this means.
     S0001: InvalidToken {
         ($span:expr, $did_you_mean:expr) => {{
+            use crate::diagnostics::*;
+
             let mut diag = Diagnostic::span_err(
                 $span,
                 "Invalid token",
@@ -53,8 +55,8 @@ define_errors! {
                 None,
             )
             .with_note("token must be mathematically significant");
-            if let Some((did_you_mean, span)) = $did_you_mean {
-                diag = diag.with_spanned_help(span, format!(r#"did you mean "{}"?"#, did_you_mean));
+            if let Some((did_you_mean, _)) = $did_you_mean {
+                diag = diag.with_autofix(Autofix::maybe("did you mean", Edit::Replace(did_you_mean.to_string())))
             }
             diag
         }}

--- a/slide/src/diagnostics.rs
+++ b/slide/src/diagnostics.rs
@@ -3,7 +3,7 @@
 //! The diagnostics module translates [libslide diagnostics](libslide::diagnostics) into a form
 //! pleasant for standard output.
 
-use libslide::diagnostics::{AssociatedDiagnostic, Diagnostic, DiagnosticKind};
+use libslide::diagnostics::{AssociatedDiagnostic, Autofix, Diagnostic, DiagnosticKind, Edit};
 
 use annotate_snippets::{
     display_list::{DisplayList, FormatOptions},
@@ -31,13 +31,38 @@ pub fn emit_slide_diagnostics(
     for (i, diagnostic) in diagnostics.iter().enumerate() {
         let main_annotation_type = convert_diagnostic_kind(&diagnostic.kind);
         let mut annotations = Vec::with_capacity(diagnostic.associated_diagnostics.len() + 1);
+
         // The first annotation always points to the code that generated this diagnostic.
-        let label = diagnostic.msg.clone().unwrap_or_default();
+        // Generally, this is immediately followed by an autofix message (if we have one) over the
+        //   code.
+        // However, to provide a nice interface, in the case that the diagnostic does not have any
+        //   message, and we have an autofix message to provide, we merge the autofix message into
+        //   the diagnostic message, and thus only annotate the code once.
+        let autofix = diagnostic
+            .autofix
+            .as_ref()
+            .map(|af| convert_autofix(&af, diagnostic.span.into()))
+            .unwrap_or_else(SourceAnnotationShim::dummy);
+        let main_label = diagnostic.msg.clone().unwrap_or_default();
+
+        let has_autofix = !autofix.is_dummy();
+        let merge_autofix = main_label.is_empty() && has_autofix;
+
+        let (first_label, first_annotation_type) = if merge_autofix {
+            (&autofix.label, AnnotationType::Help)
+        } else {
+            (&main_label, main_annotation_type)
+        };
+
         annotations.push(SourceAnnotation {
-            label: &label,
-            annotation_type: main_annotation_type,
+            label: first_label,
+            annotation_type: first_annotation_type,
             range: diagnostic.span.into(),
         });
+        if has_autofix && !merge_autofix {
+            annotations.push(autofix.deshim());
+        }
+
         // Add the associated diagnostics as the remaining annotations for the main diagnostic.
         for associated_diagnostic in diagnostic.associated_diagnostics.iter() {
             annotations.push(SourceAnnotation {
@@ -46,6 +71,7 @@ pub fn emit_slide_diagnostics(
                 range: associated_diagnostic.span.into(),
             });
         }
+
         // Add the unspanned associated diagnostics to the diagnostic footer.
         let mut footer = Vec::with_capacity(1);
         for associated_diagnostic in diagnostic.unspanned_associated_diagnostics.iter() {
@@ -77,6 +103,16 @@ pub fn emit_slide_diagnostics(
     emitted_diagnostics
 }
 
+/// Converts a slide DiagnosticKind to an AnnotationType.
+fn convert_diagnostic_kind(diagnostic_kind: &DiagnosticKind) -> AnnotationType {
+    match diagnostic_kind {
+        DiagnosticKind::Error => AnnotationType::Error,
+        DiagnosticKind::Warning => AnnotationType::Warning,
+        DiagnosticKind::Note => AnnotationType::Note,
+        DiagnosticKind::Help => AnnotationType::Help,
+    }
+}
+
 /// Converts a slide AssociatedDiagnostic to a SourceAnnotation.
 fn convert_associated_diagnostic(diagnostic: &AssociatedDiagnostic) -> Annotation {
     Annotation {
@@ -86,12 +122,60 @@ fn convert_associated_diagnostic(diagnostic: &AssociatedDiagnostic) -> Annotatio
     }
 }
 
-/// Converts a slide DiagnosticKind to an AnnotationType.
-fn convert_diagnostic_kind(diagnostic_kind: &DiagnosticKind) -> AnnotationType {
-    match diagnostic_kind {
-        DiagnosticKind::Error => AnnotationType::Error,
-        DiagnosticKind::Warning => AnnotationType::Warning,
-        DiagnosticKind::Note => AnnotationType::Note,
-        DiagnosticKind::Help => AnnotationType::Help,
+/// Converts a slide [`Autofix`](Autofix) to a [`SourceAnnotationShim`](SourceAnnotationShim),
+/// which can then be converted to a `SourceAnnotation`.
+fn convert_autofix(autofix: &Autofix, range: (usize, usize)) -> SourceAnnotationShim {
+    let suffix = match &autofix.fix {
+        Edit::Delete => "".to_owned(),
+        Edit::Replace(replacement) => format!(": `{}`", replacement),
+    };
+    SourceAnnotationShim {
+        range,
+        label: format!("{}{}", autofix.msg, suffix),
+        annotation_type: AnnotationType::Help,
+    }
+}
+
+/// `SourceAnnotation` has a `label` field of type `&'a str`, but
+/// [`convert_autofix`](convert_autofix) creates a fresh `String` when translating the diagnostic
+/// message. Thus it would be impossible for us to directly return a type of `SourceAnnotation` from
+/// there, because the lifetime of `label` would be only as long as the local reference to the
+/// message we created and was destroyed when the function exits.
+///
+/// For this reason, we provide a shim a captures the `String` label in a container returned from
+/// such functions. The shim container is owned the caller, and so the caller can then create a
+/// `SourceAnnotation` as desired, lasting the lifetime of the shim.
+struct SourceAnnotationShim {
+    range: (usize, usize),
+    label: String,
+    annotation_type: AnnotationType,
+}
+impl SourceAnnotationShim {
+    fn deshim(&self) -> SourceAnnotation {
+        SourceAnnotation {
+            range: self.range,
+            label: &self.label,
+            annotation_type: self.annotation_type,
+        }
+    }
+
+    const DUMMY_RANGE: (usize, usize) = (31459, 26535);
+
+    /// Because sometimes `SourceAnnotation`s needing a shim are created `Option`s, there is a need
+    /// to provide a shim whether the `Option` has a value or not. The "dummy shim" provides a
+    /// workaround for this need; if a user needs to unwrap the `Option` to create a shim, they can
+    /// default to the dummy shim and use [`is_dummy`](Self::is_dummy) to check if the shim is
+    /// synthetic or real.
+    fn dummy() -> Self {
+        Self {
+            range: Self::DUMMY_RANGE,
+            label: String::new(),
+            annotation_type: AnnotationType::Info,
+        }
+    }
+
+    /// Returns whether the shim is synthetic. See [`dummy`](Self::dummy).
+    fn is_dummy(&self) -> bool {
+        self.range == Self::DUMMY_RANGE
     }
 }

--- a/slide/src/test/ui/error/define-assign.slide
+++ b/slide/src/test/ui/error/define-assign.slide
@@ -9,8 +9,7 @@ arg :  = 5
 error[S0001]: Invalid token
   |
 1 | arg :  = 5 
-  |     ^
-  |     ---- help: did you mean ":="?
+  |     - help: did you mean: `:=`
   |
   = note: token must be mathematically significant
 ~~~stderr

--- a/slide/src/test/ui/error/expected_close_bracket.slide
+++ b/slide/src/test/ui/error/expected_close_bracket.slide
@@ -10,7 +10,8 @@ error[P0003]: Mismatched closing delimiter ``)``
   |
 1 | 1 + [2 * 3) - 5 
   |           ^ expected closing `]`
-  |     - help: opening `[` here
+  |           - help: change the delimiter: `]`
+  |     - note: opening `[` here
   |
 ~~~stderr
 

--- a/slide/src/test/ui/error/expected_close_bracket_eof.slide
+++ b/slide/src/test/ui/error/expected_close_bracket_eof.slide
@@ -10,7 +10,8 @@ error[P0003]: Mismatched closing delimiter `end of file`
   |
 1 | 1 + [2 * 3 
   |           ^ expected closing `]`
-  |     - help: opening `[` here
+  |           - help: change the delimiter: `]`
+  |     - note: opening `[` here
   |
 ~~~stderr
 

--- a/slide/src/test/ui/error/expected_close_paren.slide
+++ b/slide/src/test/ui/error/expected_close_paren.slide
@@ -10,7 +10,8 @@ error[P0003]: Mismatched closing delimiter ``]``
   |
 1 | 1 + (2 * 3] - 5 
   |           ^ expected closing `)`
-  |     - help: opening `(` here
+  |           - help: change the delimiter: `)`
+  |     - note: opening `(` here
   |
 ~~~stderr
 

--- a/slide/src/test/ui/error/expected_close_paren_eof.slide
+++ b/slide/src/test/ui/error/expected_close_paren_eof.slide
@@ -10,7 +10,8 @@ error[P0003]: Mismatched closing delimiter `end of file`
   |
 1 | 1 + (2 * 3 
   |           ^ expected closing `)`
-  |     - help: opening `(` here
+  |           - help: change the delimiter: `)`
+  |     - note: opening `(` here
   |
 ~~~stderr
 

--- a/slide/src/test/ui/error/missing_expr_and_closer.slide
+++ b/slide/src/test/ui/error/missing_expr_and_closer.slide
@@ -16,7 +16,8 @@ error[P0003]: Mismatched closing delimiter `end of file`
   |
 1 | 1 + (2 * 
   |         ^ expected closing `)`
-  |     - help: opening `(` here
+  |         - help: change the delimiter: `)`
+  |     - note: opening `(` here
   |
 ~~~stderr
 

--- a/slide/src/test/ui/error/multiple_missing_closer.slide
+++ b/slide/src/test/ui/error/multiple_missing_closer.slide
@@ -16,21 +16,24 @@ error[P0003]: Mismatched closing delimiter `end of file`
   |
 1 | 1 + 2 + ( [ ( 
   |              ^ expected closing `)`
-  |             - help: opening `(` here
+  |              - help: change the delimiter: `)`
+  |             - note: opening `(` here
   |
 
 error[P0003]: Mismatched closing delimiter `end of file`
   |
 1 | 1 + 2 + ( [ ( 
   |              ^ expected closing `]`
-  |           - help: opening `[` here
+  |              - help: change the delimiter: `]`
+  |           - note: opening `[` here
   |
 
 error[P0003]: Mismatched closing delimiter `end of file`
   |
 1 | 1 + 2 + ( [ ( 
   |              ^ expected closing `)`
-  |         - help: opening `(` here
+  |              - help: change the delimiter: `)`
+  |         - note: opening `(` here
   |
 ~~~stderr
 

--- a/slide/src/test/ui/error/open_paren_then_eof.slide
+++ b/slide/src/test/ui/error/open_paren_then_eof.slide
@@ -16,7 +16,8 @@ error[P0003]: Mismatched closing delimiter `end of file`
   |
 1 | 1 + 2 + ( 
   |          ^ expected closing `)`
-  |         - help: opening `(` here
+  |          - help: change the delimiter: `)`
+  |         - note: opening `(` here
   |
 ~~~stderr
 

--- a/slide/src/test/ui/error/pattern/any_pat_in_expr.slide
+++ b/slide/src/test/ui/error/pattern/any_pat_in_expr.slide
@@ -10,8 +10,8 @@ error[P0004]: Patterns cannot be used in an expression
   |
 1 | 1 + _any 
   |     ^^^^ unexpected pattern
+  |     ---- help: use a variable: `any`
   |
-  = help: consider using "any" as a variable
 ~~~stderr
 
 ~~~exitcode

--- a/slide/src/test/ui/error/pattern/const_pat_in_expr.slide
+++ b/slide/src/test/ui/error/pattern/const_pat_in_expr.slide
@@ -10,8 +10,8 @@ error[P0004]: Patterns cannot be used in an expression
   |
 1 | 1 + #const 
   |     ^^^^^^ unexpected pattern
+  |     ------ help: use a variable: `const`
   |
-  = help: consider using "const" as a variable
 ~~~stderr
 
 ~~~exitcode

--- a/slide/src/test/ui/error/pattern/var_pat_in_expr.slide
+++ b/slide/src/test/ui/error/pattern/var_pat_in_expr.slide
@@ -10,8 +10,8 @@ error[P0004]: Patterns cannot be used in an expression
   |
 1 | 1 + $var 
   |     ^^^^ unexpected pattern
+  |     ---- help: use a variable: `var`
   |
-  = help: consider using "var" as a variable
 ~~~stderr
 
 ~~~exitcode

--- a/slide/src/test/ui/error/variable/var_in_expr_pat.slide
+++ b/slide/src/test/ui/error/variable/var_in_expr_pat.slide
@@ -14,8 +14,8 @@ error[P0005]: Variables cannot be used in an expression pattern
   |
 1 | 1 + var 
   |     ^^^ unexpected variable
+  |     --- help: use a var pattern: `$var`
   |
-  = help: consider using "$var", "#var", or "_var" as a pattern
 ~~~stderr
 
 ~~~exitcode

--- a/slide/src/test/ui/extra_items.slide
+++ b/slide/src/test/ui/extra_items.slide
@@ -10,12 +10,14 @@
 ~~~stderr
 error[P0001]: Unexpected extra tokens
   |
-1 |   1 + 0 -1 2 3
-  |  __________^
-  |            - help: if you meant to specify another statement, add a newline before this token
-2 | |   4 5 6 / 7 ^ 8
-3 | |   9 
-  | |____^ not connected to a primary statement
+1 |    1 + 0 -1 2 3
+  |   __________^
+  |   __________-
+  |             - help: if you meant to specify another statement, add a newline before this token
+2 | ||   4 5 6 / 7 ^ 8
+3 |  |   9 
+  | ||____^ not connected to a primary statement
+  |  |____- help: consider deleting these tokens
   |
 ~~~stderr
 

--- a/slide/src/test/ui/extra_items_expr_pat.slide
+++ b/slide/src/test/ui/extra_items_expr_pat.slide
@@ -14,11 +14,13 @@ _a + $b -#c + 1 2
 ~~~stderr
 error[P0001]: Unexpected extra tokens
   |
-1 |   _a + $b -#c + 1 2
-  |  _________________^
-2 | | 3 4 5 6 / 7 ^ 8
-3 | |   9 
-  | |____^ not connected to a primary statement
+1 |    _a + $b -#c + 1 2
+  |   _________________^
+  |   _________________-
+2 | || 3 4 5 6 / 7 ^ 8
+3 |  |   9 
+  | ||____^ not connected to a primary statement
+  |  |____- help: consider deleting these tokens
   |
 ~~~stderr
 

--- a/slide/src/test/ui/issue_240.slide
+++ b/slide/src/test/ui/issue_240.slide
@@ -10,6 +10,7 @@ error[P0001]: Unexpected extra tokens
   |
 1 | 1 + 垐y1 + _any 
   |       ^^^^^^^^ not connected to a primary statement
+  |       -------- help: consider deleting these tokens
   |       - help: if you meant to specify another statement, add a newline before this token
   |
 ~~~stderr

--- a/slide/src/test/ui/issue_248.slide
+++ b/slide/src/test/ui/issue_248.slide
@@ -10,6 +10,7 @@ error[P0006]: Unmatched closing delimiter ")"
   |
 1 | ڝԗ+ c) 
   |      ^ has no matching opener "("
+  |      - help: consider deleting this token
   |
 ~~~stderr
 

--- a/slide/src/test/ui/issue_251_1.slide
+++ b/slide/src/test/ui/issue_251_1.slide
@@ -12,6 +12,7 @@ error[P0006]: Unmatched closing delimiter ")"
 1 | 1+c
 2 | )] a + 2 + 3 
   | ^ has no matching opener "("
+  | - help: consider deleting this token
   |
 
 error[P0006]: Unmatched closing delimiter "]"
@@ -19,6 +20,7 @@ error[P0006]: Unmatched closing delimiter "]"
 1 | 1+c
 2 | )] a + 2 + 3 
   |  ^ has no matching opener "["
+  |  - help: consider deleting this token
   |
 
 error[P0001]: Unexpected extra tokens
@@ -26,6 +28,7 @@ error[P0001]: Unexpected extra tokens
 1 | 1+c
 2 | )] a + 2 + 3 
   |    ^^^^^^^^^ not connected to a primary statement
+  |    --------- help: consider deleting these tokens
   |    - help: if you meant to specify another statement, add a newline before this token
   |
 ~~~stderr

--- a/slide/src/test/ui/issue_251_2.slide
+++ b/slide/src/test/ui/issue_251_2.slide
@@ -10,18 +10,21 @@ error[P0006]: Unmatched closing delimiter ")"
   |
 1 | 1+c )] a + 2 + 3 
   |     ^ has no matching opener "("
+  |     - help: consider deleting this token
   |
 
 error[P0006]: Unmatched closing delimiter "]"
   |
 1 | 1+c )] a + 2 + 3 
   |      ^ has no matching opener "["
+  |      - help: consider deleting this token
   |
 
 error[P0001]: Unexpected extra tokens
   |
 1 | 1+c )] a + 2 + 3 
   |        ^^^^^^^^^ not connected to a primary statement
+  |        --------- help: consider deleting these tokens
   |        - help: if you meant to specify another statement, add a newline before this token
   |
 ~~~stderr

--- a/slide/src/test/ui/issue_254.slide
+++ b/slide/src/test/ui/issue_254.slide
@@ -16,6 +16,7 @@ error[P0001]: Unexpected extra tokens
   |
 1 | 1 +  *ц 
   |       ^ not connected to a primary statement
+  |       - help: consider deleting these tokens
   |       - help: if you meant to specify another statement, add a newline before this token
   |
 ~~~stderr

--- a/slide/src/test/ui/lint/homogenous_assignment_assign_define.slide
+++ b/slide/src/test/ui/lint/homogenous_assignment_assign_define.slide
@@ -25,6 +25,7 @@ warning[L0004]: Mixed use of assignment operators
   |   -- note: first use of ":=" as an assignment operator here
 2 | b = 2
   |   - expected ":=" here
+  |   - help: replace this operator: `:=`
   |
 
 warning[L0004]: Mixed use of assignment operators
@@ -34,6 +35,7 @@ warning[L0004]: Mixed use of assignment operators
 2 | b = 2
 3 | c = 3
   |   - expected ":=" here
+  |   - help: replace this operator: `:=`
   |
 
 warning[L0004]: Mixed use of assignment operators
@@ -43,6 +45,7 @@ warning[L0004]: Mixed use of assignment operators
 ...
 5 | e = 5 
   |   - expected ":=" here
+  |   - help: replace this operator: `:=`
   |
 ~~~stderr
 

--- a/slide/src/test/ui/lint/homogenous_assignment_equal.slide
+++ b/slide/src/test/ui/lint/homogenous_assignment_equal.slide
@@ -25,6 +25,7 @@ warning[L0004]: Mixed use of assignment operators
   |   - note: first use of "=" as an assignment operator here
 2 | b := 2
   |   -- expected "=" here
+  |   -- help: replace this operator: `=`
   |
 
 warning[L0004]: Mixed use of assignment operators
@@ -34,6 +35,7 @@ warning[L0004]: Mixed use of assignment operators
 2 | b := 2
 3 | c := 3
   |   -- expected "=" here
+  |   -- help: replace this operator: `=`
   |
 
 warning[L0004]: Mixed use of assignment operators
@@ -43,6 +45,7 @@ warning[L0004]: Mixed use of assignment operators
 ...
 5 | e := 5 
   |   -- expected "=" here
+  |   -- help: replace this operator: `=`
   |
 ~~~stderr
 

--- a/slide/src/test/ui/lint/redundant_nesting_lint.slide
+++ b/slide/src/test/ui/lint/redundant_nesting_lint.slide
@@ -14,23 +14,20 @@
 warning[L0001]: Redundant nesting
   |
 1 | ( ((1   +    [[  [2    /     ([([4])])]]]  ))) 
-  | ----------------------------------------------
+  | ---------------------------------------------- help: reduce this nesting: `(1   +    [[  [2    /     ([([4])])]]])`
   |
-  = help: consider reducing this expression to "(1   +    [[  [2    /     ([([4])])]]])"
 
 warning[L0001]: Redundant nesting
   |
 1 | ( ((1   +    [[  [2    /     ([([4])])]]]  ))) 
-  |              ----------------------------
+  |              ---------------------------- help: reduce this nesting: `[2    /     ([([4])])]`
   |
-  = help: consider reducing this expression to "[2    /     ([([4])])]"
 
 warning[L0001]: Redundant nesting
   |
 1 | ( ((1   +    [[  [2    /     ([([4])])]]]  ))) 
-  |                              ---------
+  |                              --------- help: reduce this nesting: `(4)`
   |
-  = help: consider reducing this expression to "(4)"
 ~~~stderr
 
 ~~~exitcode

--- a/slide/src/test/ui/lint/similar_name_lint.slide
+++ b/slide/src/test/ui/lint/similar_name_lint.slide
@@ -22,6 +22,7 @@ warning[L0003]: Similar name "a" used by multiple patterns
   |
 1 | _a + #a + _a + $a + #b +
   | -- "a" is used by var and const patterns as well
+  | -- help: consider picking a new name, maybe: `_aa`
   |      -- note: const pattern here
   |                -- note: var pattern here
 2 | #a + _b + $b + #b + $b +
@@ -32,6 +33,7 @@ warning[L0003]: Similar name "b" used by multiple patterns
   |
 1 | _a + #a + _a + $a + #b +
   |                     -- "b" is used by var and any patterns as well
+  |                     -- help: consider picking a new name, maybe: `#bb`
 2 | #a + _b + $b + #b + $b +
   |      -- note: any pattern here
   |           -- note: var pattern here
@@ -43,6 +45,7 @@ warning[L0003]: Similar name "c" used by multiple patterns
 ...
 3 | $c + _c + #c + $c + _a +
   | -- "c" is used by const and any patterns as well
+  | -- help: consider picking a new name, maybe: `$cc`
   |      -- note: any pattern here
   |           -- note: const pattern here
   |
@@ -52,6 +55,7 @@ warning[L0003]: Similar name "d" used by multiple patterns
 ...
 4 | _d + #d + #d +
   | -- "d" is used by const patterns as well
+  | -- help: consider picking a new name, maybe: `_dd`
   |      -- note: const pattern here
   |           -- note: const pattern here
   |
@@ -61,6 +65,7 @@ warning[L0003]: Similar name "e" used by multiple patterns
 ...
 5 | $e + _e +
   | -- "e" is used by an any pattern as well
+  | -- help: consider picking a new name, maybe: `$ee`
   |      -- note: any pattern here
   |
 
@@ -69,6 +74,7 @@ warning[L0003]: Similar name "f" used by multiple patterns
 ...
 6 | #f + $f +
   | -- "f" is used by a var pattern as well
+  | -- help: consider picking a new name, maybe: `#ff`
   |      -- note: var pattern here
   |
 
@@ -77,6 +83,7 @@ warning[L0003]: Similar name "gosh" used by multiple patterns
 ...
 7 | _gosh + #gosh 
   | ----- "gosh" is used by a const pattern as well
+  | ----- help: consider picking a new name, maybe: `_goshh`
   |         ----- note: const pattern here
   |
 ~~~stderr

--- a/slide/src/test/ui/lint/unary_series_lint.slide
+++ b/slide/src/test/ui/lint/unary_series_lint.slide
@@ -14,30 +14,26 @@
 warning[L0002]: Trivially reducible unary operator chain
   |
 1 | ++++(+-+-+-[1 / --2 * (---3)]) 
-  | ------------------------------
+  | ------------------------------ help: reduce this expression: `(+-+-+-[1 / --2 * (---3)])`
   |
-  = help: consider reducing this expression to "(+-+-+-[1 / --2 * (---3)])"
 
 warning[L0002]: Trivially reducible unary operator chain
   |
 1 | ++++(+-+-+-[1 / --2 * (---3)]) 
-  |      ------------------------
+  |      ------------------------ help: reduce this expression: `-[1 / --2 * (---3)]`
   |
-  = help: consider reducing this expression to "-[1 / --2 * (---3)]"
 
 warning[L0002]: Trivially reducible unary operator chain
   |
 1 | ++++(+-+-+-[1 / --2 * (---3)]) 
-  |                 ---
+  |                 --- help: reduce this expression: `2`
   |
-  = help: consider reducing this expression to "2"
 
 warning[L0002]: Trivially reducible unary operator chain
   |
 1 | ++++(+-+-+-[1 / --2 * (---3)]) 
-  |                        ----
+  |                        ---- help: reduce this expression: `-3`
   |
-  = help: consider reducing this expression to "-3"
 ~~~stderr
 
 ~~~exitcode

--- a/slide/src/test/ui/multi_stmt/multi_stmt_needs_newline.slide
+++ b/slide/src/test/ui/multi_stmt/multi_stmt_needs_newline.slide
@@ -10,6 +10,7 @@ error[P0001]: Unexpected extra tokens
   |
 1 | 1 + 2 / 3 * 6 10 * 5 ^ 2 
   |               ^^^^^^^^^^ not connected to a primary statement
+  |               ---------- help: consider deleting these tokens
   |               -- help: if you meant to specify another statement, add a newline before this token
   |
 ~~~stderr

--- a/slide/src/test/ui/tokens_past_expr.slide
+++ b/slide/src/test/ui/tokens_past_expr.slide
@@ -10,6 +10,7 @@ error[P0001]: Unexpected extra tokens
   |
 1 | 1 2 3 
   |   ^^^ not connected to a primary statement
+  |   --- help: consider deleting these tokens
   |   - help: if you meant to specify another statement, add a newline before this token
   |
 ~~~stderr


### PR DESCRIPTION
This patch adds support for programatic declaration of autofixes that
can be applied to diagnostics, and their implementation for many of the
current diagnostics. Presently these autofixes are just formatted and
displayed during emit, but later on they can be used to provide an
`--autofix` or similar CLI flag that will automatically apply fixes to a
program, or for use in a language service (cf #303).

Closes #304
Milestone 0.0.2 (second to last one!)
PTAL @lukebhan